### PR TITLE
[zod-openapi] change `regex` to `pattern` to match OpenAPI spec

### DIFF
--- a/libs/zod-openapi/src/lib/zod-openapi.spec.ts
+++ b/libs/zod-openapi/src/lib/zod-openapi.spec.ts
@@ -135,7 +135,7 @@ describe('zodOpenapi', () => {
         aStringEmail: { type: 'string', format: 'email' },
         aStringUrl: { type: 'string', format: 'uri' },
         aStringUUID: { type: 'string', format: 'uuid' },
-        aStringRegex: { type: 'string', regex: /^[a-zA-Z]+$/ },
+        aStringRegex: { type: 'string', pattern: '^[a-zA-Z]+$' },
         aStringNonEmpty: { type: 'string', minLength: 1 },
       },
       required: [],

--- a/libs/zod-openapi/src/lib/zod-openapi.ts
+++ b/libs/zod-openapi/src/lib/zod-openapi.ts
@@ -111,7 +111,7 @@ function parseString({
         baseSchema.minLength = item.value;
         break;
       case 'regex':
-        baseSchema.regex = item.regex;
+        baseSchema.pattern = item.regex.source;
         break;
     }
   });


### PR DESCRIPTION
Source: https://swagger.io/docs/specification/data-models/data-types/#pattern

Noticed in my testing that `zod-openapi` treats `z.string().regex(...)` as a string type with a `regex` property that is the regex itself, however according to the OpenAPI spec, this is actually incorrect and should follow what JSON Schema does, which is a `pattern` property that contains the source pattern for the regex.

This corrects it by changing that `regex` property to match the spec. It could be considered a breaking change I suppose (due to the removal of a field), but its making the library like up with OAPI more so more of a fix IMO.