### PR TITLE
ZodValidationPipe: Update error handling to more closely match the default NestJS ValidationPipe

### DIFF
--- a/libs/zod-nestjs/src/lib/http-errors.ts
+++ b/libs/zod-nestjs/src/lib/http-errors.ts
@@ -1,0 +1,47 @@
+import {
+  BadGatewayException,
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  GatewayTimeoutException,
+  GoneException,
+  HttpStatus,
+  ImATeapotException,
+  InternalServerErrorException,
+  MethodNotAllowedException,
+  NotAcceptableException,
+  NotFoundException,
+  NotImplementedException,
+  PayloadTooLargeException,
+  PreconditionFailedException,
+  RequestTimeoutException,
+  ServiceUnavailableException,
+  UnauthorizedException,
+  UnprocessableEntityException,
+  UnsupportedMediaTypeException,
+} from '@nestjs/common';
+
+// This is the same list of HTTP errors as used by the NestJS ValidationPipe.
+// https://github.com/nestjs/nest/blob/85b0dc84953802d33ae8753df02adb84d6d0f0e8/packages/common/utils/http-error-by-code.util.ts#L46
+
+export const HTTP_ERRORS_BY_CODE = {
+  [HttpStatus.BAD_GATEWAY]: BadGatewayException,
+  [HttpStatus.BAD_REQUEST]: BadRequestException,
+  [HttpStatus.CONFLICT]: ConflictException,
+  [HttpStatus.FORBIDDEN]: ForbiddenException,
+  [HttpStatus.GATEWAY_TIMEOUT]: GatewayTimeoutException,
+  [HttpStatus.GONE]: GoneException,
+  [HttpStatus.I_AM_A_TEAPOT]: ImATeapotException,
+  [HttpStatus.INTERNAL_SERVER_ERROR]: InternalServerErrorException,
+  [HttpStatus.METHOD_NOT_ALLOWED]: MethodNotAllowedException,
+  [HttpStatus.NOT_ACCEPTABLE]: NotAcceptableException,
+  [HttpStatus.NOT_FOUND]: NotFoundException,
+  [HttpStatus.NOT_IMPLEMENTED]: NotImplementedException,
+  [HttpStatus.PAYLOAD_TOO_LARGE]: PayloadTooLargeException,
+  [HttpStatus.PRECONDITION_FAILED]: PreconditionFailedException,
+  [HttpStatus.REQUEST_TIMEOUT]: RequestTimeoutException,
+  [HttpStatus.SERVICE_UNAVAILABLE]: ServiceUnavailableException,
+  [HttpStatus.UNAUTHORIZED]: UnauthorizedException,
+  [HttpStatus.UNPROCESSABLE_ENTITY]: UnprocessableEntityException,
+  [HttpStatus.UNSUPPORTED_MEDIA_TYPE]: UnsupportedMediaTypeException,
+} as const;

--- a/libs/zod-nestjs/src/lib/zod-validation-pipe.ts
+++ b/libs/zod-nestjs/src/lib/zod-validation-pipe.ts
@@ -24,7 +24,7 @@ export class ZodValidationPipe implements PipeTransform {
 
   constructor(@Optional() options?: ZodValidationPipeOptions) {
     this.errorHttpStatusCode =
-      options?.errorHttpStatusCode || HttpStatus.UNPROCESSABLE_ENTITY;
+      options?.errorHttpStatusCode || HttpStatus.BAD_REQUEST;
   }
 
   public transform(value: unknown, metadata: ArgumentMetadata): unknown {

--- a/libs/zod-nestjs/src/lib/zod-validation-pipe.ts
+++ b/libs/zod-nestjs/src/lib/zod-validation-pipe.ts
@@ -1,5 +1,5 @@
 /**
- * This file is taken directly from:
+ * This file was originally taken directly from:
  *   https://github.com/kbkk/abitia/blob/master/packages/zod-dto/src/ZodValidationPipe.ts
  */
 
@@ -22,13 +22,11 @@ export class ZodValidationPipe implements PipeTransform {
 
       if (!parseResult.success) {
         const { error } = parseResult;
-        const message = error.errors
-          .map((error) => `${error.path.join('.')}: ${error.message}`)
-          .join(', ');
-
-        throw new UnprocessableEntityException(
-          `Input validation failed: ${message}`
+        const message = error.errors.map(
+          (error) => `${error.path.join('.')}: ${error.message}`
         );
+
+        throw new UnprocessableEntityException(message);
       }
 
       return parseResult.data;


### PR DESCRIPTION
Update the behavior of the ZodValidationPipe when an invalid request is found to more closely match the default NestJS ValidationPipe.

As in the default NestJS ValidationPipe:
- The default http response status code is 400 Bad Request instead of 422 Unprocessable Entity.
- The http response status code can be customized using the same "errorHttpStatusCode" option.
- The message field in the response body is an array rather than a string, making it easier to read.