### PR TITLE
zod-nestjs: Allow using the zodSchema field to construct other types

### DIFF
--- a/libs/zod-nestjs/src/lib/create-zod-dto.spec.ts
+++ b/libs/zod-nestjs/src/lib/create-zod-dto.spec.ts
@@ -20,3 +20,15 @@ describe('static create()', () => {
     expect(() => TestDto.create({ val: 123 })).toThrow(ZodError);
   });
 });
+
+describe('static zodSchema', () => {
+  it('should allow using the zodSchema field to construct other types', () => {
+    expect(
+      TestDto.zodSchema.extend({ extraField: z.string() }).parse({
+        val: 'test',
+        extraField: 'extra',
+        unrecognizedField: 'unrecognized',
+      })
+    ).toEqual({ val: 'test', extraField: 'extra' });
+  });
+});

--- a/libs/zod-nestjs/src/lib/create-zod-dto.ts
+++ b/libs/zod-nestjs/src/lib/create-zod-dto.ts
@@ -1,6 +1,6 @@
 import * as z from 'zod';
 /**
- * This file is taken from:
+ * This file was originally taken from:
  *   https://github.com/kbkk/abitia/blob/master/packages/zod-dto/src/createZodDto.ts
  *
  * It is used to create a DTO from a Zod object.
@@ -11,7 +11,7 @@ import * as z from 'zod';
  * ZodType is a very complex interface describing not just public properties but private ones as well
  * causing the interface to change fairly often among versions
  *
- * Since we're interested in the main subset of Zod functionality (type infering + parsing) this type is introduced
+ * Since we're interested in the main subset of Zod functionality (type inferring + parsing) this type is introduced
  * to achieve the most compatibility.
  */
 export type CompatibleZodType = Pick<
@@ -20,20 +20,20 @@ export type CompatibleZodType = Pick<
 >;
 export type CompatibleZodInfer<T extends CompatibleZodType> = T['_output'];
 
-export type ZodDtoStatic<T> = {
-  new (): T;
-  zodSchema: CompatibleZodType;
-  create(input: unknown): T;
+export type ZodDtoStatic<T extends CompatibleZodType = CompatibleZodType> = {
+  new (): CompatibleZodInfer<T>;
+  zodSchema: T;
+  create(input: unknown): CompatibleZodInfer<T>;
 };
 
 export const createZodDto = <T extends CompatibleZodType>(
   zodSchema: T
-): ZodDtoStatic<CompatibleZodInfer<T>> => {
+): ZodDtoStatic<T> => {
   class SchemaHolderClass {
     public static zodSchema = zodSchema;
 
-    public static create(input: unknown): T {
-      return this.zodSchema.parse(input) as T;
+    public static create(input: unknown): CompatibleZodInfer<T> {
+      return this.zodSchema.parse(input);
     }
   }
 

--- a/libs/zod-nestjs/src/lib/zod-validation-pipe.ts
+++ b/libs/zod-nestjs/src/lib/zod-validation-pipe.ts
@@ -28,7 +28,7 @@ export class ZodValidationPipe implements PipeTransform {
   }
 
   public transform(value: unknown, metadata: ArgumentMetadata): unknown {
-    const zodSchema = (metadata?.metatype as ZodDtoStatic<unknown>)?.zodSchema;
+    const zodSchema = (metadata?.metatype as ZodDtoStatic)?.zodSchema;
 
     if (zodSchema) {
       const parseResult = zodSchema.safeParse(value);


### PR DESCRIPTION
The static zodSchema field on the DTO classes now maintains the schema
type that is passed in, which allows it to be used to construct other
schemas. Previously this zodSchema field had type "CompatibleZodType"
rather than "T extends CompatibleZodType" which meant that most of the
type information was lost.

Workarounds:
Although not as concise, the schema value can be exported separately or
the zodSchema field can be redefined on each DTO class that needs it.

Breaking change:
The "T" in ZodDtoStatic<T> has changed from the output type to the
schema type. Code that is using the ZodDtoStatic type directly may need
to be updated. No changes are needed if just using the DTOs.

Examples:

```TypeScript
// user.dto.ts

import { createZodDto } from '@anatine/zod-nestjs';
import { z } from 'zod';

const schema = z.object({ name: z.string() });

export class UserDto extends createZodDto(schema) {}

// users-list.dto.ts (has an array of users)

import { createZodDto } from '@anatine/zod-nestjs';
import { z } from 'zod';
import { UserDto } from './user.dto';

// Previously produced a TypeScript error: Property 'array' does not exist on type 'CompatibleZodType'.
const schema = z.object({ items: UserDto.zodSchema.array() });

export class UsersListDto extends createZodDto(schema) {}

// extended-user.dto.ts (a user with an additional field)

import { createZodDto } from '@anatine/zod-nestjs';
import { z } from 'zod';
import { UserDto } from './user.dto';

// Previously produced a TypeScript error: Property 'extend' does not exist on type 'CompatibleZodType'.
const schema = UserDto.zodSchema.extend({ group: z.string() });

export class ExtendedUserDto extends createZodDto(schema) {}
```