### PR TITLE
Removing console.log and adding eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,6 +2,9 @@
   "root": true,
   "ignorePatterns": ["**/*"],
   "plugins": ["@nrwl/nx"],
+  "rules": {
+    "no-console": ["error", { "allow": ["warn", "error"] }]
+  },
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],

--- a/libs/zod-mock/package.json
+++ b/libs/zod-mock/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@anatine/zod-mock",
+  "name": "@ezlogic/zod-mock",
   "version": "3.0.0",
   "description": "Zod auto-mock object generator using Faker at @faker-js/faker",
   "main": "src/index.js",
@@ -8,12 +8,12 @@
   "public": true,
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/anatine/zod-plugins"
+    "url": "git+https://github.com/gustavopedroni/zod-plugins"
   },
-  "homepage": "https://github.com/anatine/zod-plugins/tree/main/packages/zod-mock",
+  "homepage": "https://github.com/gustavopedroni/zod-plugins/tree/main/packages/zod-mock",
   "author": {
-    "name": "Brian McBride",
-    "url": "https://www.linkedin.com/in/brianmcbride"
+    "name": "Ezlogic",
+    "url": "http://www.ezlogic.com.br/"
   },
   "keywords": [
     "zod",

--- a/libs/zod-mock/src/lib/zod-mock.ts
+++ b/libs/zod-mock/src/lib/zod-mock.ts
@@ -139,8 +139,6 @@ function parseTransform(
 ) {
   const input = generateMock(zodRef._def.schema, options);
 
-  console.log(zodRef._def.effect);
-
   const effect =
     zodRef._def.effect.type === 'transform'
       ? zodRef._def.effect


### PR DESCRIPTION
- Removing console.log because it ends up generating logs in some application that consumes it;
- Adding Eslint rule to avoid this problem;