### PR TITLE
Updates the findMatchingFaker function to guarantee that the Faker function is of type fakerFunction

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,16 +1,12 @@
 {
-  "workbench.colorCustomizations": {
-    "activityBar.background": "#22285C",
-    "titleBar.activeBackground": "#303981",
-    "titleBar.activeForeground": "#F9FAFD"
-  },
   "cSpell.words": [
+    "Nonpositive",
+    "Unprocessable",
     "anatidae",
     "deepmerge",
     "esbuild",
+    "mersenne",
     "metatype",
-    "Nonpositive",
-    "openapi",
-    "Unprocessable"
+    "openapi"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,9 @@
 {
+  "workbench.colorCustomizations": {
+    "activityBar.background": "#22285C",
+    "titleBar.activeBackground": "#303981",
+    "titleBar.activeForeground": "#F9FAFD"
+  },
   "cSpell.words": [
     "Nonpositive",
     "Unprocessable",

--- a/libs/zod-mock/package.json
+++ b/libs/zod-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anatine/zod-mock",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Zod auto-mock object generator using Faker at @faker-js/faker",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/libs/zod-mock/src/lib/zod-mock.spec.ts
+++ b/libs/zod-mock/src/lib/zod-mock.spec.ts
@@ -38,7 +38,7 @@ describe('zod-mock', () => {
     expect(mockData.age > 18 && mockData.age < 120).toBeTruthy();
   });
 
-  it('should generate generate mock data of the appropriate type when the field names overlap Faker properties that are not valid functions', () => {
+  it('should generate mock data of the appropriate type when the field names overlap Faker properties that are not valid functions', () => {
     const schema = z.object({
       // the following fields represent non function properties in Faker
       lorem: z.string(),

--- a/libs/zod-mock/src/lib/zod-mock.spec.ts
+++ b/libs/zod-mock/src/lib/zod-mock.spec.ts
@@ -38,6 +38,28 @@ describe('zod-mock', () => {
     expect(mockData.age > 18 && mockData.age < 120).toBeTruthy();
   });
 
+  it('should generate generate mock data of the appropriate type when the field names overlap Faker properties that are not valid functions', () => {
+    const schema = z.object({
+      // the following fields represent non function properties in Faker
+      lorem: z.string(),
+      phone_number: z.string().min(10).optional(),
+
+      // 'shuffle', located at `faker.helpers.shuffle`, is a function, but does not
+      // produce the appropriate return type to match `fakerFunction`
+      shuffle: z.string(),
+
+      // 'seed', located at `faker.mersenne.seed` is a function but will throw an error
+      // if it is called with the wrong parameter
+      seed: z.string()
+    });
+
+    const mockData = generateMock(schema);
+    expect(typeof mockData.lorem).toEqual('string');
+    expect(typeof mockData.phone_number).toEqual('string');
+    expect(typeof mockData.shuffle).toEqual('string');
+    expect(typeof mockData.seed).toEqual('string');
+  });
+
   it('Should manually mock string key names to set values', () => {
     const schema = z.object({
       uid: z.string().nonempty(),


### PR DESCRIPTION
While using this library I encountered an error that would not allow me to continue using it. My schema has a field called 'phone_number'. The name is dictated by a third party and I cannot change it. Faker has a property at `faker.definitions.phone_number` which is not a function. This property was being found and this library was attempting to call it which threw an error.

This PR fixes this issue by verifying that the Faker function name which is returned by the `findMatchingFaker` function adheres to the `fakerFunction` type.

Additionally:
- searches for faker functions against `keyName` values after removing underscores and dashes. This allows key names such as 'phone_number' to utilize the most correct Faker function of `phoneNumber`
- adds unit test to verify functionality of changes.