### PR TITLE
min/max handling for strings and arrays

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
     "Nonpositive",
     "Unprocessable",
     "anatidae",
+    "anatine",
     "deepmerge",
     "esbuild",
     "mersenne",

--- a/libs/zod-mock/README.md
+++ b/libs/zod-mock/README.md
@@ -113,6 +113,20 @@ const mockData = generateMock(schema, {
 
   Some zod filter types (email, uuid, url, min, max, length) will also modify the results.
 
+  If **`zod-mock`** does not yet support a Zod type used in your schema, you may provide a backup mock function to use for that particular type.
+
+  ``` typescript
+  const schema = z.object({
+    anyVal: z.any()
+  });
+
+  const mockData = generateMock(schema, {
+    backupMocks: {
+      ZodAny: () => 'a value'
+    }
+  });
+  ```
+
 ----
 
 ## Missing Features

--- a/libs/zod-mock/README.md
+++ b/libs/zod-mock/README.md
@@ -113,7 +113,6 @@ const mockData = generateMock(schema, {
 
 ## Missing Features
 
-- String length constraints are not taken into account
 - No pattern for passing options into `faker`, such as setting phone number formatting
 
 ----

--- a/libs/zod-mock/README.md
+++ b/libs/zod-mock/README.md
@@ -42,6 +42,7 @@ const mockData = generateMock(schema);
 ```
 
 This will generate mock data similar to:
+
 ```json
 {
   "uid": "3f46b40e-95ed-43d0-9165-0b8730de8d14",
@@ -101,24 +102,40 @@ const mockData = generateMock(schema, {
 **`zod-mock`** tries to generate mock data from two sources.
 
 - ### Object key name ie(`{ firstName: z.string() }`)
+  
   This will check the string name of the key against all the available `faker` function names.
   Upon a match, it uses that function to generate a mock value.
+
 - ### Zodtype ie(`const something =  z.string()`)
+  
   In the case there is no key name (the schema doesn't contain an object) or there is no key name match,
   `zod-mock` will use the primitive type provided by `zod`.
 
-  Some zod filter types (email, uuid, url) and number's (min, max) will also modify the results.
+  Some zod filter types (email, uuid, url, min, max, length) will also modify the results.
 
 ----
 
 ## Missing Features
 
 - No pattern for passing options into `faker`, such as setting phone number formatting
+- Does not handle the following Zod types:
+  - ZodAny
+  - ZodDefault
+  - ZodFunction
+  - ZodIntersection
+  - ZodMap
+  - ZodPromise
+  - ZodSet
+  - ZodTuple
+  - ZodUnion
+  - ZodUnknown
 
 ----
+
 ## Credits
 
 - ### [express-zod-api](https://github.com/RobinTail/express-zod-api)
+  
   A great lib that provided some insights on dealing with various zod types.
 
 ----

--- a/libs/zod-mock/package.json
+++ b/libs/zod-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anatine/zod-mock",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Zod auto-mock object generator using Faker at @faker-js/faker",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/libs/zod-mock/src/lib/zod-mock.spec.ts
+++ b/libs/zod-mock/src/lib/zod-mock.spec.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 import { generateMock } from './zod-mock';
-
 describe('zod-mock', () => {
   it('should generate a mock object using faker', () => {
     const schema = z.object({
@@ -91,4 +90,68 @@ describe('zod-mock', () => {
 
     return;
   });
+
+  it('should convert values produced by Faker to string when the schema type is string.', () => {
+    const schema = z.object({
+      number: z.string(),
+      boolean: z.string(),
+      date: z.string()
+    });
+    const mockData = generateMock(schema);
+    expect(typeof mockData.number === 'string').toBeTruthy();
+    expect(typeof mockData.boolean === 'string').toBeTruthy();
+    expect(typeof mockData.date === 'string').toBeTruthy();
+  });
+
+  it("supports generating date strings via Faker for keys of 'date' and 'dateTime'.", () => {
+    const schema = z.object({
+      date: z.string(),
+    });
+    const mockData = generateMock(schema);
+    expect(new Date(mockData.date).getTime()).not.toBeNaN();
+  });
+
+  describe('when handling min and max string lengths', () => {
+    const createSchema = (min: number, max: number) => z.object({
+      default: z.string().min(min).max(max),
+      email: z.string().min(min).max(max),
+      uuid: z.string().min(min).max(max),
+      url: z.string().min(min).max(max),
+      name: z.string().min(min).max(max),
+      color: z.string().min(min).max(max),
+      notFound: z.string().min(min).max(max),
+    })
+    it('should create mock strings that respect the specified min and max lengths (inclusive)', () => {
+      const min = 1;
+      const max = 5;
+      const mockData = generateMock(createSchema(min, max));
+
+      Object.values(mockData).forEach((val) => {
+        expect(val.length).toBeGreaterThanOrEqual(min);
+        expect(val.length).toBeLessThanOrEqual(max);
+      });
+    });
+
+    it('should respect the max length when the min is greater than the max', () => {
+      const min = 5;
+      const max = 2;
+      const mockData = generateMock(createSchema(min, max));
+
+      Object.values(mockData).forEach((val) => {
+        expect(val.length).toBeLessThanOrEqual(max);
+      });
+    });
+
+    it('should append extra string content to meet a minimum length', () => {
+      const min = 100;
+      const max = 100;
+      const mockData = generateMock(createSchema(min, max));
+
+      Object.values(mockData).forEach((val) => {
+        expect(val.length).toBeGreaterThanOrEqual(min);
+        expect(val.length).toBeLessThanOrEqual(max);
+      });
+    });
+  });
+
 });

--- a/libs/zod-mock/src/lib/zod-mock.spec.ts
+++ b/libs/zod-mock/src/lib/zod-mock.spec.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { generateMock, GenerateMockOptions } from './zod-mock';
+import { generateMock } from './zod-mock';
 describe('zod-mock', () => {
   it('should generate a mock object using faker', () => {
     const schema = z.object({

--- a/libs/zod-mock/src/lib/zod-mock.spec.ts
+++ b/libs/zod-mock/src/lib/zod-mock.spec.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { generateMock } from './zod-mock';
+import { generateMock, GenerateMockOptions } from './zod-mock';
 describe('zod-mock', () => {
   it('should generate a mock object using faker', () => {
     const schema = z.object({
@@ -212,6 +212,36 @@ describe('zod-mock', () => {
     });
   });
 
+  describe('backup mocks', () => {
+    const notUndefined = () => 'not undefined';
+    it('should use a user provided generator when a generator for the schema type cannot be found',() => {
+      // undefined is used because we have no reason to create a generator for it because the net result
+      // will be undefined.
+      const mock = generateMock(z.undefined(), { backupMocks: { ZodUndefined: notUndefined }});
+      expect(mock).toEqual(notUndefined());
+    });
+
+    it('should work with objects and arrays', () => {
+      const schema = z.object({
+        data: z.array(z.undefined()).length(1)
+      });
+      const mock = generateMock(schema, { backupMocks: { ZodUndefined: notUndefined }});
+      expect(mock.data[0]).toEqual(notUndefined());
+    });
+
+    it('should work with the README example', () => {
+      const schema = z.object({
+        anyVal: z.any()
+      });
+
+      const mockData = generateMock(schema, {
+        backupMocks: {
+          ZodAny: () => 'any value'
+        }
+      });
+      expect(mockData.anyVal).toEqual('any value');
+    });
+  });
 
   // TODO: enable tests as their test types are implemented
   xdescribe('missing types', () => {

--- a/libs/zod-mock/src/lib/zod-mock.spec.ts
+++ b/libs/zod-mock/src/lib/zod-mock.spec.ts
@@ -103,7 +103,7 @@ describe('zod-mock', () => {
     expect(typeof mockData.date === 'string').toBeTruthy();
   });
 
-  it("supports generating date strings via Faker for keys of 'date' and 'dateTime'.", () => {
+  it("should support generating date strings via Faker for keys of 'date' and 'dateTime'.", () => {
     const schema = z.object({
       date: z.string(),
     });
@@ -154,4 +154,113 @@ describe('zod-mock', () => {
     });
   });
 
+  describe('arrays', () => {
+    it('should mock an array without min or max', () => {
+      const schema = z.object({
+        data: z.array(z.string()),
+      });
+      const mockData = generateMock(schema);
+      expect(mockData.data.length).toBeTruthy();
+      expect(typeof mockData.data[0] === 'string');
+    });
+
+    it('should mock an array with a min, but no max', () => {
+      const schema = z.object({
+        data: z.array(z.string()).min(3),
+      });
+      const mockData = generateMock(schema);
+      expect(mockData.data.length).toBeGreaterThanOrEqual(3);
+      expect(typeof mockData.data[0] === 'string');
+    });
+
+    it('should mock an array with a max, but no min', () => {
+      const schema = z.object({
+        data: z.array(z.string()).max(1),
+      });
+      const mockData = generateMock(schema);
+      expect(mockData.data.length).toEqual(1);
+      expect(typeof mockData.data[0] === 'string');
+    });
+
+    it('should mock an array of length 10', () => {
+      const schema = z.object({
+        data: z.array(z.string()).length(10),
+      });
+      const mockData = generateMock(schema);
+      expect(mockData.data.length).toEqual(10);
+      expect(typeof mockData.data[0] === 'string');
+    });
+
+    it('should accurately mock a zero length array', () => {
+      const schema = z.object({
+        alwaysEmpty: z.array(z.string()).max(0),
+      });
+      const mockData = generateMock(schema);
+      expect(mockData.alwaysEmpty.length).toEqual(0);
+    });
+
+    it('should generate different value instances per array element', () => {
+      const schema = z.object({
+        data: z.array(z.date()).length(2),
+      });
+      const mockData = generateMock(schema);
+      expect(mockData.data.length).toEqual(2);
+      // even if the two dates represent the same instant in time,
+      // they should not be the same instance if we are mocking each
+      // array element separately.
+      expect(mockData.data[0] === mockData.data[1]).toBeFalsy();
+    });
+  });
+
+
+  // TODO: enable tests as their test types are implemented
+  xdescribe('missing types', () => {
+    it('ZodAny', () => {
+      expect(generateMock(z.any())).toBeTruthy();
+    })
+    it('ZodDefault', () => {
+      expect(generateMock(z.string().default('a'))).toBeTruthy();
+    })
+
+    it('ZodFunction', () => {
+      expect(generateMock(z.function())).toBeTruthy();
+    })
+
+    it('ZodIntersection', () => {
+      const Person = z.object({
+        name: z.string(),
+      });
+
+      const Employee = z.object({
+        role: z.string(),
+      });
+
+      const EmployedPerson = z.intersection(Person, Employee);
+      expect(generateMock(EmployedPerson)).toBeTruthy();
+    })
+
+    it('ZodMap', () => {
+      expect(generateMock(z.map(z.string(), z.string()))).toBeTruthy();
+    })
+
+    it('ZodPromise', () => {
+      expect(generateMock(z.promise(z.string()))).toBeTruthy();
+    })
+
+    it('ZodSet', () => {
+      expect(generateMock(z.set(z.string()))).toBeTruthy();
+    })
+    it('ZodTuple', () => {
+      expect(generateMock(z.tuple([z.string()]))).toBeTruthy();
+    })
+
+    it('ZodUnion', () => {
+      expect(generateMock(z.union([z.number(), z.string()]))).toBeTruthy();
+    })
+
+    it('ZodUnknown', () => {
+      expect(generateMock(z.unknown())).toBeTruthy();
+    })
+
+  });
 });

--- a/libs/zod-mock/src/lib/zod-mock.spec.ts
+++ b/libs/zod-mock/src/lib/zod-mock.spec.ts
@@ -66,14 +66,16 @@ describe('zod-mock', () => {
       theme: z.enum([`light`, `dark`]),
       locked: z.string(),
       email: z.string().email(),
+      camelCase: z.string()
     });
 
-    const mockData = generateMock(schema, {
-      stringMap: {
-        locked: () => `value set`,
-        email: () => `not a email anymore`,
-      },
-    }); //?
+    const stringMap = {
+      locked: () => `value set`,
+      email: () => `not a email anymore`,
+      camelCase: () => 'Exact case works',
+    }
+
+    const mockData = generateMock(schema, { stringMap }); //?
 
     expect(mockData.uid).toEqual(
       expect.stringMatching(
@@ -85,6 +87,7 @@ describe('zod-mock', () => {
     expect(mockData.email).toEqual(
       expect.stringMatching('not a email anymore')
     );
+    expect(mockData.camelCase).toEqual(stringMap.camelCase())
 
     return;
   });

--- a/libs/zod-mock/src/lib/zod-mock.ts
+++ b/libs/zod-mock/src/lib/zod-mock.ts
@@ -147,7 +147,6 @@ function parseString(
   // will never parse without producing errors, we will prioritize
   // the max value because exceeding it represents a potential security
   // vulnerability (buffer overflows).
-  // return generator().toString();
   let val = generator().toString();
   const delta = targetStringLength - val.length;
   if (stringOptions.min != null && val.length < stringOptions.min) {

--- a/libs/zod-mock/src/lib/zod-mock.ts
+++ b/libs/zod-mock/src/lib/zod-mock.ts
@@ -60,7 +60,14 @@ function parseString(
   options?: GenerateMockOptions
 ): string | number | boolean {
   const { checks = [] } = zodRef._def;
-
+  const lowerCaseKeyName = options?.keyName?.toLowerCase();
+  // prioritize user provided generators
+  // if(options?.keyName && options.stringMap) {
+  //   const generator = options.stringMap[options.keyName];
+  //   if (generator) {
+  //     return generator();
+  //   }
+  // }
   const stringGenerators = {
     default: faker.lorem.word,
     email: faker.internet.exampleEmail,
@@ -91,7 +98,7 @@ function parseString(
   const stringType =
     (Object.keys(stringGenerators).find(
       (genKey) =>
-        genKey === options?.keyName?.toLowerCase() ||
+        genKey.toLowerCase() === lowerCaseKeyName ||
         checks.find((item) => item.kind === genKey)
     ) as keyof typeof stringGenerators) || null;
 

--- a/libs/zod-mock/src/lib/zod-mock.ts
+++ b/libs/zod-mock/src/lib/zod-mock.ts
@@ -185,10 +185,19 @@ function parseOptional(
 }
 
 function parseArray(zodRef: z.ZodArray<never>, options?: GenerateMockOptions) {
-  const s = generateMock<ZodTypeAny>(zodRef._def.type, options);
-  return [s, s, s, s, s].map(() =>
-    generateMock<ZodTypeAny>(zodRef._def.type, options)
-  );
+  let min = zodRef._def.minLength?.value != null ? zodRef._def.minLength.value : 1;
+  const max = zodRef._def.maxLength?.value != null ? zodRef._def.maxLength.value : 5;
+
+  // prevents arrays from exceeding the max regardless of the min.
+  if (min > max){
+    min = max;
+  }
+  const targetLength = faker.datatype.number({min, max});
+  const results: ZodTypeAny[] = [];
+  for (let index = 0; index < targetLength; index++) {
+    results.push(generateMock<ZodTypeAny>(zodRef._def.type, options))
+  }
+  return results;
 }
 
 function parseEnum(zodRef: z.ZodEnum<never> | z.ZodNativeEnum<never>) {

--- a/libs/zod-mock/src/lib/zod-mock.ts
+++ b/libs/zod-mock/src/lib/zod-mock.ts
@@ -188,7 +188,11 @@ type WorkerKeys = keyof typeof workerMap;
 
 export interface GenerateMockOptions {
   keyName?: string;
-  stringMap?: Record<string, (args: any) => string>;
+  /**
+   * Note: callback functions are not called with any
+   * parameters at this time.
+   */
+  stringMap?: Record<string, (...args: any[]) => string>;
 }
 
 export function generateMock<T extends ZodTypeAny>(


### PR DESCRIPTION
This PR adds support for handling min/max schema specifications for strings and arrays. In both cases, the max length will be respected over the min length. 

Additionally, support is added for backup mock functions being provided via the options parameter. This allows clients to specify mock functions for use with Zod types that are not yet supported by this library.