### PR TITLE
feat(zod-openapi): merge openapi metadata

### DIFF
--- a/libs/zod-openapi/src/lib/zod-openapi.spec.ts
+++ b/libs/zod-openapi/src/lib/zod-openapi.spec.ts
@@ -676,4 +676,25 @@ describe('zodOpenapi', () => {
       description: 'A user schema',
     });
   });
+
+  it('merges openapi metadata when extendApi is used more than one', () => {
+    const timestampSchema = extendApi(z.string(), {
+      format: 'date-time',
+      description: 'A timestamp.',
+    });
+
+    const newDescription = 'A more specific timestamp.';
+
+    const overriddenSchema = extendApi(timestampSchema, {
+      description: newDescription,
+    });
+
+    const openapiSchema = generateSchema(overriddenSchema);
+
+    expect(openapiSchema).toMatchObject({
+      type: 'string',
+      format: 'date-time',
+      description: newDescription,
+    });
+  });
 });

--- a/libs/zod-openapi/src/lib/zod-openapi.ts
+++ b/libs/zod-openapi/src/lib/zod-openapi.ts
@@ -20,7 +20,7 @@ export function extendApi<T extends OpenApiZodAny>(
   schema: T,
   SchemaObject: SchemaObject = {}
 ): T {
-  schema.metaOpenApi = SchemaObject;
+  schema.metaOpenApi = Object.assign(schema.metaOpenApi || {}, SchemaObject);
   return schema;
 }
 


### PR DESCRIPTION
This PR adds a change to `extendApi` to merge the specified metadata into the existing `metaOpenApi` object, if it already exists. The motivation here is when extending a schema's openapi metadata more than once, the original information gets overwritten. 

Here's an example: 

```ts
const DateTimeSchema = extendApi(z.string(), { format: 'date-time', description: 'An ISO-8601 timestamp.' })
```

Later, you may want to reuse `DateTimeSchema`, but just override the description, keeping the `format`:
```ts
const CreatedAtSchema = extendApi(DateTimeSchema, { description: 'The creation date.' }). 
```

However, `extendApi` currently overwrites whatever is in `schema.metaOpenApi`, so that `CreatedAtSchema` does not have `format: 'date-time'` anymore. 

This PR merges it, which IMO is clearer since `extendApi` suggests that whenever you extend a schema, its original properties are kept and you are adding more and/or overriding the specified properties. 