### PR TITLE
fix(zod-openapi): support unknown record value types

### DIFF
--- a/libs/zod-openapi/src/lib/zod-openapi.spec.ts
+++ b/libs/zod-openapi/src/lib/zod-openapi.spec.ts
@@ -228,15 +228,33 @@ describe('zodOpenapi', () => {
     });
   });
 
-  it('should support records', () => {
-    const zodSchema = extendApi(z.record(z.number().min(2).max(42)), {
-      description: 'Record this one for me.',
+  describe('record support', () => {
+    describe('with a value type', () => {
+      it('adds the value type to additionalProperties', () => {
+        const zodSchema = extendApi(z.record(z.number().min(2).max(42)), {
+          description: 'Record this one for me.',
+        });
+        const apiSchema = generateSchema(zodSchema);
+        expect(apiSchema).toEqual({
+          type: 'object',
+          additionalProperties: { type: 'number', minimum: 2, maximum: 42 },
+          description: 'Record this one for me.',
+        });
+      });
     });
-    const apiSchema = generateSchema(zodSchema);
-    expect(apiSchema).toEqual({
-      type: 'object',
-      additionalProperties: { type: 'number', minimum: 2, maximum: 42 },
-      description: 'Record this one for me.',
+
+    describe('with unknown value types', () => {
+      it('leaves additionalProperties blank', () => {
+        const zodSchema = extendApi(z.record(z.unknown()), {
+          description: 'Record this one for me.',
+        });
+        const apiSchema = generateSchema(zodSchema);
+        expect(apiSchema).toEqual({
+          type: 'object',
+          additionalProperties: {},
+          description: 'Record this one for me.',
+        });
+      });
     });
   });
 

--- a/libs/zod-openapi/src/lib/zod-openapi.ts
+++ b/libs/zod-openapi/src/lib/zod-openapi.ts
@@ -207,7 +207,10 @@ function parseRecord({
   return merge(
     {
       type: 'object',
-      additionalProperties: generateSchema(zodRef._def.valueType, useOutput),
+      additionalProperties:
+        zodRef._def.valueType instanceof z.ZodUnknown
+          ? {}
+          : generateSchema(zodRef._def.valueType, useOutput),
     },
     ...schemas
   );


### PR DESCRIPTION
When parsing a record with an unknown value type, e.g:

```ts
const recordSchema = extendApi(z.record(z.unknown()), { 
  description: 'A record with unknown value types.' 
});
```

Which is equivalent to the commonly used typescript type `Record<string, unknown>`.

when passed through generateSchema, it comes back with the following invalid JSON schema:

```js
{
  type: 'object',
  additionalProperties: { nullable: true },
  description: 'A record with unknown value types.' 
}
```

ajv v8 comes back with the following error:
```
Error message: "\"nullable\" cannot be used without \"type\""
```

I think `ZodUnknown`, when passed through to generateSchema, will come back with `{ nullable: true }`, which perhaps is desirable in other situations, just not in a `record`. This PR explicitly checks for `ZodUnknown` in `parseRecord` and returns an empty object instead.

Also added a test for this. 