### PR TITLE
fix: record type and swap string min when greater than max

### DIFF
--- a/libs/zod-mock/src/lib/zod-mock.spec.ts
+++ b/libs/zod-mock/src/lib/zod-mock.spec.ts
@@ -2,6 +2,10 @@ import { z } from 'zod';
 import { generateMock } from './zod-mock';
 describe('zod-mock', () => {
   it('should generate a mock object using faker', () => {
+    enum NativeEnum {
+      a = 1,
+      b = 2,
+    }
     const schema = z.object({
       uid: z.string().nonempty(),
       theme: z.enum([`light`, `dark`]),
@@ -16,7 +20,8 @@ describe('zod-mock', () => {
       stringLength: z.string().transform((val) => val.length),
       numberCount: z.number().transform((item) => `total value = ${item}`),
       age: z.number().min(18).max(120),
-      record: z.record(z.string(), z.number())
+      record: z.record(z.string(), z.number()),
+      nativeEnum: z.nativeEnum(NativeEnum)
     });
 
     const mockData = generateMock(schema); //?
@@ -38,6 +43,7 @@ describe('zod-mock', () => {
     expect(mockData.age > 18 && mockData.age < 120).toBeTruthy();
     expect(typeof mockData.record).toEqual('object');
     expect(typeof Object.values(mockData.record)[0]).toEqual('number');
+    expect(mockData.nativeEnum === 1 || mockData.nativeEnum === 2);
   });
 
   it('should generate mock data of the appropriate type when the field names overlap Faker properties that are not valid functions', () => {

--- a/libs/zod-mock/src/lib/zod-mock.spec.ts
+++ b/libs/zod-mock/src/lib/zod-mock.spec.ts
@@ -16,6 +16,7 @@ describe('zod-mock', () => {
       stringLength: z.string().transform((val) => val.length),
       numberCount: z.number().transform((item) => `total value = ${item}`),
       age: z.number().min(18).max(120),
+      record: z.record(z.string(), z.number())
     });
 
     const mockData = generateMock(schema); //?
@@ -35,6 +36,8 @@ describe('zod-mock', () => {
     expect(typeof mockData.stringLength).toEqual('number');
     expect(typeof mockData.numberCount).toEqual('string');
     expect(mockData.age > 18 && mockData.age < 120).toBeTruthy();
+    expect(typeof mockData.record).toEqual('object');
+    expect(typeof Object.values(mockData.record)[0]).toEqual('number');
   });
 
   it('should generate mock data of the appropriate type when the field names overlap Faker properties that are not valid functions', () => {
@@ -324,7 +327,7 @@ describe('zod-mock', () => {
     expect(regResult.data).toMatch(/^[A-Z0-9+_.-]+@[A-Z0-9.-]+$/);
   });
 
-  it.only('should handle complex unions', () => {
+  it('should handle complex unions', () => {
     const result = generateMock(z.object({ date: z.date() }));
     expect(result.date).toBeInstanceOf(Date);
 

--- a/libs/zod-mock/src/lib/zod-mock.ts
+++ b/libs/zod-mock/src/lib/zod-mock.ts
@@ -276,6 +276,12 @@ function parseEnum(zodRef: z.ZodEnum<never> | z.ZodNativeEnum<never>) {
   return values[pick];
 }
 
+function parseNativeEnum(zodRef: z.ZodEnum<never> | z.ZodNativeEnum<never>) {
+  const { values } = zodRef._def;
+  const pick = Math.floor(Math.random() * (Object.values(values).length / 2));
+  return values[values[pick]];
+}
+
 function parseLiteral(zodRef: z.ZodLiteral<any>) {
   return zodRef._def.value;
 }
@@ -317,7 +323,7 @@ const workerMap = {
   ZodNullable: parseOptional,
   ZodArray: parseArray,
   ZodEnum: parseEnum,
-  ZodNativeEnum: parseEnum,
+  ZodNativeEnum: parseNativeEnum,
   ZodLiteral: parseLiteral,
   ZodTransformer: parseTransform,
   ZodEffects: parseTransform,

--- a/libs/zod-mock/src/lib/zod-mock.ts
+++ b/libs/zod-mock/src/lib/zod-mock.ts
@@ -276,7 +276,7 @@ function parseEnum(zodRef: z.ZodEnum<never> | z.ZodNativeEnum<never>) {
   return values[pick];
 }
 
-function parseNativeEnum(zodRef: z.ZodEnum<never> | z.ZodNativeEnum<never>) {
+function parseNativeEnum(zodRef: z.ZodNativeEnum<never>) {
   const { values } = zodRef._def;
   const pick = Math.floor(Math.random() * (Object.values(values).length / 2));
   return values[values[pick]];


### PR DESCRIPTION
1. z.record  will cause TypeError: Cannot convert undefined or null to object

so I add a parseRecord to handle ZodRecord。

2. In addition to this，this pr fixes `[Error]: Max 2 should be greater than min 5.` error in spec.ts。

![image](https://user-images.githubusercontent.com/23290513/180631231-8ad1053e-27e3-480f-9106-f9d7f8f7bbbe.png)

3. fix .nativeEnum mock data was undefined error
