### PR TITLE
fix: nativeEnum random pick function bias

### DIFF
--- a/packages/zod-mock/src/lib/zod-mock.ts
+++ b/packages/zod-mock/src/lib/zod-mock.ts
@@ -292,7 +292,7 @@ function parseEnum(zodRef: z.ZodEnum<never> | z.ZodNativeEnum<never>) {
 
 function parseNativeEnum(zodRef: z.ZodNativeEnum<never>) {
 	const { values } = zodRef._def;
-	const pick = Math.floor(Math.random() * (Object.values(values).length / 2));
+	const pick = Math.floor(Math.random() * (Object.values(values).length));
 	const key = Array.from(Object.keys(values))[pick];
 	return values[values[key]];
 }


### PR DESCRIPTION
It is no longer necesary to divide by 2 the length of the enum object keys, as string enum do not have double binding ( { 0: "SOMETHING", SOMETHING: 0}).