### PR TITLE
zod-mock: Add missing type generators

### DIFF
--- a/packages/zod-mock/src/lib/zod-mock.spec.ts
+++ b/packages/zod-mock/src/lib/zod-mock.spec.ts
@@ -352,7 +352,9 @@ describe('zod-mock', () => {
     });
 
     it('ZodFunction', () => {
-      expect(generateMock(z.function())).toBeTruthy();
+      const func = generateMock(z.function(z.tuple([]), z.string()));
+      expect(func).toBeTruthy();
+      expect(typeof func()).toBe('string');
     });
 
     it('ZodIntersection', () => {

--- a/packages/zod-mock/src/lib/zod-mock.spec.ts
+++ b/packages/zod-mock/src/lib/zod-mock.spec.ts
@@ -346,8 +346,11 @@ describe('zod-mock', () => {
   it('ZodAny', () => {
     expect(generateMock(z.any())).toBeTruthy();
   });
+
   it('ZodDefault', () => {
-      expect(generateMock(z.string().default('a'))).toBeTruthy();
+    const value = generateMock(z.string().default('a'));
+    expect(value).toBeTruthy();
+    expect(typeof value).toBe('string');
   });
 
   it('ZodFunction', () => {
@@ -372,8 +375,11 @@ describe('zod-mock', () => {
     expect(generated.role).toBeTruthy();
   });
 
-  it('ZodPromise', () => {
-    expect(generateMock(z.promise(z.string()))).toBeTruthy();
+  it('ZodPromise', async () => {
+    const promise = generateMock(z.promise(z.string()));
+    expect(promise).toBeTruthy();
+    const result = await promise;
+    expect(typeof result).toBe('string');
   });
 
   describe('ZodTuple', () => {

--- a/packages/zod-mock/src/lib/zod-mock.spec.ts
+++ b/packages/zod-mock/src/lib/zod-mock.spec.ts
@@ -52,9 +52,9 @@ describe('zod-mock', () => {
     expect(typeof mockData.record).toEqual('object');
     expect(typeof Object.values(mockData.record)[0]).toEqual('number');
     expect(mockData.nativeEnum === 1 || mockData.nativeEnum === 2);
-    expect(mockData.set).toBeTruthy()
-    expect(mockData.map).toBeTruthy()
-    expect(mockData.discriminatedUnion).toBeTruthy()
+    expect(mockData.set).toBeTruthy();
+    expect(mockData.map).toBeTruthy();
+    expect(mockData.discriminatedUnion).toBeTruthy();
   });
 
   it('should generate mock data of the appropriate type when the field names overlap Faker properties that are not valid functions', () => {
@@ -375,10 +375,34 @@ describe('zod-mock', () => {
       expect(generateMock(z.promise(z.string()))).toBeTruthy();
     });
 
-    it('ZodTuple', () => {
-      expect(generateMock(z.tuple([z.string()]))).toBeTruthy();
-    });
+    describe('ZodTuple', () => {
+      it('basic tuple', () => {
+        const generated = generateMock(
+          z.tuple([z.number(), z.string(), z.boolean()])
+        );
+        expect(generated).toBeTruthy();
+        const [n, s, b] = generated;
 
+        expect(typeof n).toBe('number');
+        expect(typeof s).toBe('string');
+        expect(typeof b).toBe('boolean');
+      });
+
+      it('tuple with Rest args', () => {
+        const generated = generateMock(
+          z.tuple([z.number(), z.boolean()]).rest(z.string())
+        );
+        expect(generated).toBeTruthy();
+        const [n, b, ...rest] = generated;
+
+        expect(typeof n).toBe('number');
+        expect(typeof b).toBe('boolean');
+        expect(rest.length).toBeGreaterThan(0);
+        for (const item of rest) {
+          expect(typeof item).toBe('string');
+        }
+      });
+    });
     it('ZodUnion', () => {
       expect(generateMock(z.union([z.number(), z.string()]))).toBeTruthy();
     });

--- a/packages/zod-mock/src/lib/zod-mock.spec.ts
+++ b/packages/zod-mock/src/lib/zod-mock.spec.ts
@@ -343,7 +343,7 @@ describe('zod-mock', () => {
   });
 
   // TODO: enable tests as their test types are implemented
-  xdescribe('missing types', () => {
+  describe('missing types', () => {
     it('ZodAny', () => {
       expect(generateMock(z.any())).toBeTruthy();
     });

--- a/packages/zod-mock/src/lib/zod-mock.spec.ts
+++ b/packages/zod-mock/src/lib/zod-mock.spec.ts
@@ -343,8 +343,13 @@ describe('zod-mock', () => {
   });
 
   // TODO: enable tests as their test types are implemented
-  it('ZodAny', () => {
-    expect(generateMock(z.any())).toBeTruthy();
+  xdescribe('missing types', () => {
+    it('ZodAny', () => {
+      expect(generateMock(z.any())).toBeTruthy();
+    });
+    it('ZodUnknown', () => {
+      expect(generateMock(z.unknown())).toBeTruthy();
+    });
   });
 
   it('ZodDefault', () => {
@@ -414,9 +419,6 @@ describe('zod-mock', () => {
     expect(generateMock(z.union([z.number(), z.string()]))).toBeTruthy();
   });
 
-  it('ZodUnknown', () => {
-    expect(generateMock(z.unknown())).toBeTruthy();
-  });
   it(`Avoid depreciations in strings`, () => {
     const warn = jest
       .spyOn(console, 'warn')
@@ -491,5 +493,28 @@ describe('zod-mock', () => {
     } else {
       expect(result.userName).toBeTruthy();
     }
+  });
+
+  it('should handle branded types', () => {
+    const Branded = z.string().brand<'__brand'>();
+
+    const result = generateMock(Branded);
+    expect(result).toBeTruthy();
+  });
+
+  it('ZodVoid', () => {
+    expect(generateMock(z.void())).toBeUndefined();
+  });
+  it('ZodNull', () => {
+    expect(generateMock(z.null())).toBeNull();
+  });
+  it('ZodNaN', () => {
+    expect(generateMock(z.nan())).toBeNaN();
+  });
+  it('ZodUndefined', () => {
+    expect(generateMock(z.undefined())).toBeUndefined();
+  });
+  it('ZodLazy', () => {
+    expect(generateMock(z.lazy(() => z.string()))).toBeTruthy();
   });
 });

--- a/packages/zod-mock/src/lib/zod-mock.spec.ts
+++ b/packages/zod-mock/src/lib/zod-mock.spec.ts
@@ -343,77 +343,74 @@ describe('zod-mock', () => {
   });
 
   // TODO: enable tests as their test types are implemented
-  describe('missing types', () => {
-    it('ZodAny', () => {
-      expect(generateMock(z.any())).toBeTruthy();
-    });
-    it('ZodDefault', () => {
+  it('ZodAny', () => {
+    expect(generateMock(z.any())).toBeTruthy();
+  });
+  it('ZodDefault', () => {
       expect(generateMock(z.string().default('a'))).toBeTruthy();
-    });
-
-    it('ZodFunction', () => {
-      const func = generateMock(z.function(z.tuple([]), z.string()));
-      expect(func).toBeTruthy();
-      expect(typeof func()).toBe('string');
-    });
-
-    it('ZodIntersection', () => {
-      const Person = z.object({
-        name: z.string(),
-      });
-
-      const Employee = z.object({
-        role: z.string(),
-      });
-
-      const EmployedPerson = z.intersection(Person, Employee);
-      const generated = generateMock(EmployedPerson);
-      expect(generated).toBeTruthy();
-      expect(generated.name).toBeTruthy();
-      expect(generated.role).toBeTruthy();
-    });
-
-    it('ZodPromise', () => {
-      expect(generateMock(z.promise(z.string()))).toBeTruthy();
-    });
-
-    describe('ZodTuple', () => {
-      it('basic tuple', () => {
-        const generated = generateMock(
-          z.tuple([z.number(), z.string(), z.boolean()])
-        );
-        expect(generated).toBeTruthy();
-        const [n, s, b] = generated;
-
-        expect(typeof n).toBe('number');
-        expect(typeof s).toBe('string');
-        expect(typeof b).toBe('boolean');
-      });
-
-      it('tuple with Rest args', () => {
-        const generated = generateMock(
-          z.tuple([z.number(), z.boolean()]).rest(z.string())
-        );
-        expect(generated).toBeTruthy();
-        const [n, b, ...rest] = generated;
-
-        expect(typeof n).toBe('number');
-        expect(typeof b).toBe('boolean');
-        expect(rest.length).toBeGreaterThan(0);
-        for (const item of rest) {
-          expect(typeof item).toBe('string');
-        }
-      });
-    });
-    it('ZodUnion', () => {
-      expect(generateMock(z.union([z.number(), z.string()]))).toBeTruthy();
-    });
-
-    it('ZodUnknown', () => {
-      expect(generateMock(z.unknown())).toBeTruthy();
-    });
   });
 
+  it('ZodFunction', () => {
+    const func = generateMock(z.function(z.tuple([]), z.string()));
+    expect(func).toBeTruthy();
+    expect(typeof func()).toBe('string');
+  });
+
+  it('ZodIntersection', () => {
+    const Person = z.object({
+      name: z.string(),
+    });
+
+    const Employee = z.object({
+      role: z.string(),
+    });
+
+    const EmployedPerson = z.intersection(Person, Employee);
+    const generated = generateMock(EmployedPerson);
+    expect(generated).toBeTruthy();
+    expect(generated.name).toBeTruthy();
+    expect(generated.role).toBeTruthy();
+  });
+
+  it('ZodPromise', () => {
+    expect(generateMock(z.promise(z.string()))).toBeTruthy();
+  });
+
+  describe('ZodTuple', () => {
+    it('basic tuple', () => {
+      const generated = generateMock(
+        z.tuple([z.number(), z.string(), z.boolean()])
+      );
+      expect(generated).toBeTruthy();
+      const [num, str, bool] = generated;
+
+      expect(typeof num).toBe('number');
+      expect(typeof str).toBe('string');
+      expect(typeof bool).toBe('boolean');
+    });
+
+    it('tuple with Rest args', () => {
+      const generated = generateMock(
+        z.tuple([z.number(), z.boolean()]).rest(z.string())
+      );
+      expect(generated).toBeTruthy();
+      const [num, bool, ...rest] = generated;
+
+      expect(typeof num).toBe('number');
+      expect(typeof bool).toBe('boolean');
+      expect(rest.length).toBeGreaterThan(0);
+      for (const item of rest) {
+        expect(typeof item).toBe('string');
+      }
+    });
+  });
+  it('ZodUnion', () => {
+    expect(generateMock(z.union([z.number(), z.string()]))).toBeTruthy();
+  });
+
+  it('ZodUnknown', () => {
+    expect(generateMock(z.unknown())).toBeTruthy();
+  });
   it(`Avoid depreciations in strings`, () => {
     const warn = jest
       .spyOn(console, 'warn')

--- a/packages/zod-mock/src/lib/zod-mock.ts
+++ b/packages/zod-mock/src/lib/zod-mock.ts
@@ -401,7 +401,26 @@ function parseZodFunction(
 ) {
   return function zodMockFunction() {
     return generateMock(zodRef._def.returns, options);
+  };
+}
+
+function parseZodDefault(
+  zodRef: z.ZodDefault<ZodTypeAny>,
+  options?: GenerateMockOptions
+) {
+  // Use the default value 50% of the time
+  if (faker.datatype.boolean()) {
+    return zodRef._def.defaultValue();
+  } else {
+    return generateMock(zodRef._def.innerType, options);
   }
+}
+
+function parseZodPromise(
+  zodRef: z.ZodPromise<ZodTypeAny>,
+  options?: GenerateMockOptions
+) {
+  return Promise.resolve(generateMock(zodRef._def.type, options));
 }
 
 const workerMap = {
@@ -427,6 +446,8 @@ const workerMap = {
   ZodIntersection: parseZodIntersection,
   ZodTuple: parseZodTuple,
   ZodFunction: parseZodFunction,
+  ZodDefault: parseZodDefault,
+  ZodPromise: parseZodPromise,
 };
 
 type WorkerKeys = keyof typeof workerMap;

--- a/packages/zod-mock/src/lib/zod-mock.ts
+++ b/packages/zod-mock/src/lib/zod-mock.ts
@@ -371,6 +371,16 @@ function parseUnion(
   return faker.helpers.arrayElement(mockOptions);
 }
 
+function parseZodIntersection(
+  zodRef: z.ZodIntersection<ZodTypeAny, ZodTypeAny>,
+  options?: GenerateMockOptions
+) {
+  const left = generateMock(zodRef._def.left, options)
+  const right = generateMock(zodRef._def.right, options)
+
+  return Object.assign(left, right)
+}
+
 const workerMap = {
   ZodObject: parseObject,
   ZodRecord: parseRecord,
@@ -391,7 +401,9 @@ const workerMap = {
   ZodSet: parseSet,
   ZodMap: parseMap,
   ZodDiscriminatedUnion: parseDiscriminatedUnion,
+  ZodIntersection: parseZodIntersection
 };
+
 type WorkerKeys = keyof typeof workerMap;
 
 export interface GenerateMockOptions {

--- a/packages/zod-mock/src/lib/zod-mock.ts
+++ b/packages/zod-mock/src/lib/zod-mock.ts
@@ -325,7 +325,6 @@ function parseDiscriminatedUnion(
   zodRef: z.ZodDiscriminatedUnion<never, never, never>,
   options?: GenerateMockOptions
 ) {
-
   // Map the options to various possible union cases
   const potentialCases = [...zodRef._def.options.values()];
   const pick = Math.floor(Math.random() * potentialCases.length);
@@ -375,12 +374,26 @@ function parseZodIntersection(
   zodRef: z.ZodIntersection<ZodTypeAny, ZodTypeAny>,
   options?: GenerateMockOptions
 ) {
-  const left = generateMock(zodRef._def.left, options)
-  const right = generateMock(zodRef._def.right, options)
+  const left = generateMock(zodRef._def.left, options);
+  const right = generateMock(zodRef._def.right, options);
 
-  return Object.assign(left, right)
+  return Object.assign(left, right);
 }
+function parseZodTuple(
+  zodRef: z.ZodTuple<[], never>,
+  options?: GenerateMockOptions
+) {
+  const results: ZodTypeAny[] = [];
+  zodRef._def.items.forEach((def) => {
+    results.push(generateMock(def, options));
+  });
 
+  if (zodRef._def.rest !== null) {
+    const next = parseArray(z.array(zodRef._def.rest), options);
+    results.push(...(next ?? []));
+  }
+  return results;
+}
 const workerMap = {
   ZodObject: parseObject,
   ZodRecord: parseRecord,
@@ -401,7 +414,8 @@ const workerMap = {
   ZodSet: parseSet,
   ZodMap: parseMap,
   ZodDiscriminatedUnion: parseDiscriminatedUnion,
-  ZodIntersection: parseZodIntersection
+  ZodIntersection: parseZodIntersection,
+  ZodTuple: parseZodTuple,
 };
 
 type WorkerKeys = keyof typeof workerMap;

--- a/packages/zod-mock/src/lib/zod-mock.ts
+++ b/packages/zod-mock/src/lib/zod-mock.ts
@@ -394,6 +394,16 @@ function parseZodTuple(
   }
   return results;
 }
+
+function parseZodFunction(
+  zodRef: z.ZodFunction<z.ZodTuple<any, any>, ZodTypeAny>,
+  options?: GenerateMockOptions
+) {
+  return function zodMockFunction() {
+    return generateMock(zodRef._def.returns, options);
+  }
+}
+
 const workerMap = {
   ZodObject: parseObject,
   ZodRecord: parseRecord,
@@ -416,6 +426,7 @@ const workerMap = {
   ZodDiscriminatedUnion: parseDiscriminatedUnion,
   ZodIntersection: parseZodIntersection,
   ZodTuple: parseZodTuple,
+  ZodFunction: parseZodFunction,
 };
 
 type WorkerKeys = keyof typeof workerMap;

--- a/packages/zod-mock/src/lib/zod-mock.ts
+++ b/packages/zod-mock/src/lib/zod-mock.ts
@@ -423,6 +423,20 @@ function parseZodPromise(
   return Promise.resolve(generateMock(zodRef._def.type, options));
 }
 
+function parseBranded(
+  zodRef: z.ZodBranded<ZodTypeAny, never>,
+  options?: GenerateMockOptions
+) {
+  return generateMock(zodRef.unwrap(), options);
+}
+
+function parseLazy(
+  zodRef: z.ZodLazy<ZodTypeAny>,
+  options?: GenerateMockOptions
+) {
+  return generateMock(zodRef._def.getter(), options);
+}
+
 const workerMap = {
   ZodObject: parseObject,
   ZodRecord: parseRecord,
@@ -448,6 +462,10 @@ const workerMap = {
   ZodFunction: parseZodFunction,
   ZodDefault: parseZodDefault,
   ZodPromise: parseZodPromise,
+  ZodLazy: () => parseLazy,
+  ZodBranded: parseBranded,
+  ZodNull: () => null,
+  ZodNaN: () => NaN,
 };
 
 type WorkerKeys = keyof typeof workerMap;


### PR DESCRIPTION
I took the liberty to implement most of the missing type generators here. The only other ones I know are missing are `ZodUnknown` and `ZodAny`, but since there are a few ways to address that I didn't include any changes to those types in this PR.

The new handlers I added here are for:
- `ZodIntersection`
- `ZodTuple`
- `ZodFunction`
- `ZodDefault`
- `ZodPromise`
- `ZodLazy`
- `ZodBranded`
- `ZodNull`
- `ZodNaN`