### PR TITLE
Updates createZodDto to expose Query and Param decorated models for Swagger Generation

### DIFF
--- a/packages/zod-nestjs/src/lib/create-zod-dto.spec.ts
+++ b/packages/zod-nestjs/src/lib/create-zod-dto.spec.ts
@@ -9,6 +9,24 @@ const testDtoSchema = z.object({
 
 class TestDto extends createZodDto(testDtoSchema) {}
 
+enum TestEnum {
+  North = 1,
+  South = 2,
+}
+
+const TestDtoForOpenApiMetadataSchema = z.object({
+  stringValue: z.string().email(),
+  numberValue: z.number().max(5).min(2),
+  booleanValue: z.boolean().optional(),
+  enumValue: z.nativeEnum(TestEnum),
+  preprocessedValue: z.preprocess((arg) => {
+    const stringArg = z.string().parse(arg ?? '')
+    return parseFloat(stringArg);
+  }, z.number()),
+})
+
+class TestDtoForOpenApiMetadata extends createZodDto(TestDtoForOpenApiMetadataSchema) {}
+
 describe('static create()', () => {
   it('should create the DTO', () => {
     const result = TestDto.create({ val: 'test' });
@@ -32,3 +50,36 @@ describe('static zodSchema', () => {
     ).toEqual({ val: 'test', extraField: 'extra' });
   });
 });
+
+describe('static OPEN_API_METADATA', () => {
+  it('should properly return a record of fields in the schema', () => {
+    const records = TestDtoForOpenApiMetadata._OPENAPI_METADATA_FACTORY()
+    console.log(TestDtoForOpenApiMetadata.zodSchema);
+    expect(records).toEqual({
+      stringValue: {
+        type: 'string',
+        required: true,
+        format: 'email',
+      },
+      numberValue: {
+        type: 'number',
+        required: true,
+        maximum: 5,
+        minimum: 2,
+      },
+      booleanValue: {
+        type: 'boolean',
+        required: false,
+      },
+      enumValue: {
+        type: 'string',
+        required: true,
+        enum: ['North', 'South', 1, 2],
+      },
+      preprocessedValue: {
+        type: 'number',
+        required: true,
+      }
+    })
+  })
+})

--- a/packages/zod-nestjs/src/lib/create-zod-dto.ts
+++ b/packages/zod-nestjs/src/lib/create-zod-dto.ts
@@ -1,3 +1,5 @@
+import { generateSchema, OpenApiZodAny } from '@anatine/zod-openapi';
+import { SchemaObject } from 'openapi3-ts';
 import * as z from 'zod';
 /**
  * This file was originally taken from:
@@ -24,13 +26,51 @@ export type ZodDtoStatic<T extends CompatibleZodType = CompatibleZodType> = {
   new (): CompatibleZodInfer<T>;
   zodSchema: T;
   create(input: unknown): CompatibleZodInfer<T>;
+  _OPENAPI_METADATA_FACTORY(): Record<string, SchemaObject> | undefined;
 };
 
+// Used for transforming the SchemaObject in _OPENAPI_METADATA_FACTORY
+type SchemaObjectForMetadataFactory = Omit<SchemaObject, 'required'>;
+
 export const createZodDto = <T extends CompatibleZodType>(
-  zodSchema: T
+  zodSchema: T & OpenApiZodAny,
 ): ZodDtoStatic<T> => {
   class SchemaHolderClass {
     public static zodSchema = zodSchema;
+
+    /** Found from METADATA_FACTORY_NAME
+      * in Nestjs swagger module.
+      * https://github.com/nestjs/swagger/blob/491b168cbff3003191e55ee96e77e69d8c1deb66/lib/type-helpers/mapped-types.utils.ts
+      * METADATA_FACTORY_NAME is defined here as '_OPENAPI_METADATA_FACTORY' here:
+      * https://github.com/nestjs/swagger/blob/491b168cbff3003191e55ee96e77e69d8c1deb66/lib/plugin/plugin-constants.ts
+    */
+    public static _OPENAPI_METADATA_FACTORY(): Record<string, SchemaObject> | undefined {
+      const generatedSchema = generateSchema(zodSchema);
+      const properties = generatedSchema.properties ?? {};
+      for (const key in properties) {
+        /** For some reason the SchemaObject model has everything except for the
+         * required field, which is an array.
+         * The NestJS swagger module requires this to be a boolean representative
+         * of each property.
+         * This logic takes the SchemaObject, and turns the required field from an 
+         * array to a boolean.
+         */
+        const schemaObject = properties[key] as SchemaObjectForMetadataFactory;
+        const schemaObjectWithRequiredField = {
+          ...schemaObject
+        }
+        if (
+          (generatedSchema.required !== undefined,
+          generatedSchema.required?.includes(key))
+        ) {
+          schemaObjectWithRequiredField.required = true;
+        } else {
+          schemaObjectWithRequiredField.required = false;
+        }
+        properties[key] = schemaObjectWithRequiredField;
+      }
+      return properties;
+    }
 
     public static create(input: unknown): CompatibleZodInfer<T> {
       return this.zodSchema.parse(input);


### PR DESCRIPTION
This fixes issues where users were reporting that any objects that had Param and Query decorators were not being rendered on swagger docs in relation to the NestJS swagger module. This addresses issues from https://github.com/anatine/zod-plugins/issues/5 and https://github.com/anatine/zod-plugins/issues/35