### PR TITLE
fix: support unions in class DTO

### DIFF
--- a/apps/example/project.json
+++ b/apps/example/project.json
@@ -36,7 +36,8 @@
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "options": {
-        "lintFilePatterns": ["apps/example/**/*.ts"]
+        "lintFilePatterns": ["apps/example/**/*.ts"],
+        "ignorePath": ["node_modules"]
       },
       "outputs": ["{options.outputFile}"]
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "tslib": "^2.4.0",
         "typescript": "4.8.4",
         "validator": "^13.7.0",
-        "zod": "^3.19.1"
+        "zod": "^3.20.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -17502,9 +17502,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.19.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.19.1.tgz",
-      "integrity": "sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.0.tgz",
+      "integrity": "sha512-ZWxs7oM5ixoo1BMoxTNeDMYSih/F/FUnExsnRtHT04rG6q0Bd74TKS45RGXw07TOalOZyyzdKaYH38k8yTEv9A==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -17539,45 +17539,52 @@
     },
     "packages/zod-mock": {
       "name": "@anatine/zod-mock",
-      "version": "3.5.11",
+      "version": "3.6.0",
       "license": "MIT",
       "dependencies": {
         "randexp": "^0.5.3"
       },
       "peerDependencies": {
-        "@faker-js/faker": "^6.0.0-beta.0",
-        "randexp": "^0.5.3"
+        "@faker-js/faker": "^7.0.0"
       }
     },
     "packages/zod-nestjs": {
       "name": "@anatine/zod-nestjs",
-      "version": "1.7.4",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
-        "@anatine/zod-openapi": "^1.9.7"
+        "@anatine/zod-openapi": "^1.9.8",
+        "type-fest": "^3.3.0"
       },
       "peerDependencies": {
         "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0",
-        "openapi3-ts": "^2.0.2",
+        "@nestjs/swagger": "^6.0.0",
+        "openapi3-ts": "^2.0.0 || ^3.0.0",
         "zod": "^3.17.0 || ^3.18.0"
+      }
+    },
+    "packages/zod-nestjs/node_modules/type-fest": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.3.0.tgz",
+      "integrity": "sha512-gezeeOIZyQLGW5uuCeEnXF1aXmtt2afKspXz3YqoOcZ3l/YMJq1pujvgT+cz/Nw1O/7q/kSav5fihJHsC/AOUg==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/zod-openapi": {
       "name": "@anatine/zod-openapi",
-      "version": "1.9.8",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
-        "ts-deepmerge": "^2.0.4"
+        "ts-deepmerge": "^4.0.0"
       },
       "peerDependencies": {
-        "openapi3-ts": "^2.0.2",
-        "zod": "^3.18.0"
+        "openapi3-ts": "^2.0.0 || ^3.0.0",
+        "zod": "^3.17.0 || ^3.18.0"
       }
-    },
-    "packages/zod-openapi/node_modules/ts-deepmerge": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-2.0.7.tgz",
-      "integrity": "sha512-3phiGcxPSSR47RBubQxPoZ+pqXsEsozLo4G4AlSrsMKTFg9TA3l+3he5BqpUi9wiuDbaHWXH/amlzQ49uEdXtg=="
     }
   },
   "dependencies": {
@@ -17625,20 +17632,21 @@
     "@anatine/zod-nestjs": {
       "version": "file:packages/zod-nestjs",
       "requires": {
-        "@anatine/zod-openapi": "^1.9.7"
+        "@anatine/zod-openapi": "^1.9.8",
+        "type-fest": "^3.3.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.3.0.tgz",
+          "integrity": "sha512-gezeeOIZyQLGW5uuCeEnXF1aXmtt2afKspXz3YqoOcZ3l/YMJq1pujvgT+cz/Nw1O/7q/kSav5fihJHsC/AOUg=="
+        }
       }
     },
     "@anatine/zod-openapi": {
       "version": "file:packages/zod-openapi",
       "requires": {
-        "ts-deepmerge": "^2.0.4"
-      },
-      "dependencies": {
-        "ts-deepmerge": {
-          "version": "2.0.7",
-          "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-2.0.7.tgz",
-          "integrity": "sha512-3phiGcxPSSR47RBubQxPoZ+pqXsEsozLo4G4AlSrsMKTFg9TA3l+3he5BqpUi9wiuDbaHWXH/amlzQ49uEdXtg=="
-        }
+        "ts-deepmerge": "^4.0.0"
       }
     },
     "@angular-devkit/core": {
@@ -30807,9 +30815,9 @@
       "dev": true
     },
     "zod": {
-      "version": "3.19.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.19.1.tgz",
-      "integrity": "sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.0.tgz",
+      "integrity": "sha512-ZWxs7oM5ixoo1BMoxTNeDMYSih/F/FUnExsnRtHT04rG6q0Bd74TKS45RGXw07TOalOZyyzdKaYH38k8yTEv9A==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "tslib": "^2.4.0",
     "typescript": "4.8.4",
     "validator": "^13.7.0",
-    "zod": "^3.19.1"
+    "zod": "^3.20.0"
   },
   "workspaces": [
     "packages/**"

--- a/packages/graphql-codegen-zod/project.json
+++ b/packages/graphql-codegen-zod/project.json
@@ -18,7 +18,8 @@
       "executor": "@nrwl/linter:eslint",
       "outputs": ["{options.outputFile}"],
       "options": {
-        "lintFilePatterns": ["packages/graphql-codegen-zod/**/*.ts"]
+        "lintFilePatterns": ["packages/graphql-codegen-zod/**/*.ts"],
+        "ignorePath": ["node_modules"]
       }
     },
     "test": {

--- a/packages/graphql-zod-validation/project.json
+++ b/packages/graphql-zod-validation/project.json
@@ -18,7 +18,8 @@
       "executor": "@nrwl/linter:eslint",
       "outputs": ["{options.outputFile}"],
       "options": {
-        "lintFilePatterns": ["packages/graphql-zod-validation/**/*.ts"]
+        "lintFilePatterns": ["packages/graphql-zod-validation/**/*.ts"],
+        "ignorePath": ["node_modules"]
       }
     },
     "test": {

--- a/packages/zod-mock/project.json
+++ b/packages/zod-mock/project.json
@@ -18,7 +18,8 @@
       "executor": "@nrwl/linter:eslint",
       "outputs": ["{options.outputFile}"],
       "options": {
-        "lintFilePatterns": ["packages/zod-mock/**/*.ts"]
+        "lintFilePatterns": ["packages/zod-mock/**/*.ts"],
+        "ignorePath": ["node_modules"]
       }
     },
     "test": {

--- a/packages/zod-mock/src/lib/zod-mock.ts
+++ b/packages/zod-mock/src/lib/zod-mock.ts
@@ -268,9 +268,11 @@ function parseOptional(
 
 function parseArray(zodRef: z.ZodArray<never>, options?: GenerateMockOptions) {
   let min =
-    zodRef._def.minLength?.value != null ? zodRef._def.minLength.value : 1;
+    zodRef._def.exactLength?.value != null ? zodRef._def.exactLength.value
+    : zodRef._def.minLength?.value != null ? zodRef._def.minLength.value : 1;
   const max =
-    zodRef._def.maxLength?.value != null ? zodRef._def.maxLength.value : 5;
+    zodRef._def.exactLength?.value != null ? zodRef._def.exactLength.value
+    : zodRef._def.maxLength?.value != null ? zodRef._def.maxLength.value : 5;
 
   // prevents arrays from exceeding the max regardless of the min.
   if (min > max) {
@@ -322,7 +324,7 @@ function parseEnum(zodRef: z.ZodEnum<never> | z.ZodNativeEnum<never>) {
 }
 
 function parseDiscriminatedUnion(
-  zodRef: z.ZodDiscriminatedUnion<never, never, never>,
+  zodRef: z.ZodDiscriminatedUnion<never, never[]>,
   options?: GenerateMockOptions
 ) {
   // Map the options to various possible union cases

--- a/packages/zod-nestjs/package.json
+++ b/packages/zod-nestjs/package.json
@@ -22,7 +22,8 @@
     "nestjs"
   ],
   "dependencies": {
-    "@anatine/zod-openapi": "^1.9.8"
+    "@anatine/zod-openapi": "^1.9.8",
+    "type-fest": "^3.3.0"
   },
   "peerDependencies": {
     "zod": "^3.17.0 || ^3.18.0",

--- a/packages/zod-nestjs/project.json
+++ b/packages/zod-nestjs/project.json
@@ -19,7 +19,8 @@
       "executor": "@nrwl/linter:eslint",
       "outputs": ["{options.outputFile}"],
       "options": {
-        "lintFilePatterns": ["packages/zod-nestjs/**/*.ts"]
+        "lintFilePatterns": ["packages/zod-nestjs/**/*.ts"],
+        "ignorePath": ["node_modules"]
       }
     },
     "test": {

--- a/packages/zod-nestjs/src/lib/create-zod-dto.spec.ts
+++ b/packages/zod-nestjs/src/lib/create-zod-dto.spec.ts
@@ -29,4 +29,62 @@ describe('zod-nesjs create-zod-dto', () => {
       })
     ).toEqual({ val: 'test', extraField: 'extra' });
   });
+
+  it('should merge a discriminated union types for class', () => {
+    enum Kind { A, B };
+    const discriminatedSchema = z
+      .discriminatedUnion('kind', [
+        z.object({
+          kind: z.literal(Kind.A),
+          value: z.number()
+        }),
+        z.object({
+          kind: z.literal(Kind.B),
+          value: z.string()
+        })
+      ]);
+
+    class TestDto extends createZodDto(discriminatedSchema) {}
+
+    const result = TestDto.create({kind: Kind.A, value: 1})
+    expect(result).toEqual({ kind: Kind.A, value: 1 });
+  });
+
+  it('should merge the union types for class', () => {
+    enum Kind { A, B };
+    const unionSchema = z
+      .union([
+        z.object({
+          kind: z.literal(Kind.A),
+          value: z.number()
+        }),
+        z.object({
+          kind: z.literal(Kind.B),
+          value: z.string()
+        })
+      ]);
+
+    class TestDto extends createZodDto(unionSchema) {}
+
+    const result = TestDto.create({kind: Kind.B, value: 'val'})
+    expect(result).toEqual({ kind: Kind.B, value: 'val' });
+  });
+
+  it('should support new pipe operator', () => {
+    const TestSchema = z
+      .string()
+      .transform((arg) => {
+        const [type, value] = arg.split(' ') as [string, string];
+        return { type, value };
+      })
+      .pipe(z.object({
+        type: z.string(),
+        value: z.string()
+      }));
+
+    class TestDto extends createZodDto(TestSchema) {}
+
+    const result = TestDto.create('a test')
+    expect(result).toEqual({ type: 'a', value: 'test' });
+  });
 });

--- a/packages/zod-openapi/project.json
+++ b/packages/zod-openapi/project.json
@@ -18,7 +18,8 @@
       "executor": "@nrwl/linter:eslint",
       "outputs": ["{options.outputFile}"],
       "options": {
-        "lintFilePatterns": ["packages/zod-openapi/**/*.ts"]
+        "lintFilePatterns": ["packages/zod-openapi/**/*.ts"],
+        "ignorePath": ["node_modules"]
       }
     },
     "test": {

--- a/packages/zod-openapi/src/lib/zod-openapi.spec.ts
+++ b/packages/zod-openapi/src/lib/zod-openapi.spec.ts
@@ -391,6 +391,55 @@ describe('zodOpenapi', () => {
     });
   });
 
+  it('should support a top level discriminated union', () => {
+    enum Kind {
+      A,
+      B
+    };
+
+    const zodSchema = extendApi(
+      z
+        .discriminatedUnion('kind', [
+          z.object({
+            kind: z.literal(Kind.A),
+            value: z.number()
+          }),
+          z.object({
+            kind: z.literal(Kind.B),
+            value: z.string()
+          })
+        ]),
+      {
+        description: "Discriminatory",
+      }
+    );
+    const apiSchema = generateSchema(zodSchema);
+    expect(apiSchema).toEqual({
+      discriminator: { propertyName: 'kind' },
+      oneOf: [
+        { type: 'object', properties: {
+          kind: {
+            type: 'number',
+            enum: [0]
+          },
+          value: {
+            type: 'number'
+          }
+        }, required: ['kind', 'value'] },
+        { type: 'object', properties: {
+          kind: {
+            type: 'number',
+            enum: [1]
+          },
+          value: {
+            type: 'string'
+          }
+        }, required: ['kind', 'value'] },
+      ],
+      description: "Discriminatory",
+    });
+  });
+
   it('Testing large mixed schema', () => {
     enum Fruits {
       Apple,

--- a/packages/zod-openapi/src/lib/zod-openapi.ts
+++ b/packages/zod-openapi/src/lib/zod-openapi.ts
@@ -115,6 +115,10 @@ function parseString({
       case 'min':
         baseSchema.minLength = item.value;
         break;
+      case 'length':
+        baseSchema.minLength = item.value;
+        baseSchema.maxLength = item.value;
+        break;
       case 'regex':
         baseSchema.pattern = item.regex.source;
         break;
@@ -309,6 +313,10 @@ function parseArray({
     constraints.minItems = zodRef._def.minLength.value;
   if (zodRef._def.maxLength != null)
     constraints.maxItems = zodRef._def.maxLength.value;
+  if (zodRef._def.exactLength != null) {
+    constraints.minItems = zodRef._def.exactLength.value;
+    constraints.maxItems = zodRef._def.exactLength.value;
+  }
 
   return merge(
     {
@@ -389,27 +397,24 @@ function parseDiscriminatedUnion({
 }: ParsingArgs<
   z.ZodDiscriminatedUnion<
     string,
-    z.Primitive,
-    z.ZodDiscriminatedUnionOption<string, z.Primitive>
+    z.ZodDiscriminatedUnionOption<string>[]
   >
 >): SchemaObject {
   return merge(
     {
       discriminator: {
         propertyName: (
-          zodRef as z.ZodDiscriminatedUnion<
+          zodRef as  z.ZodDiscriminatedUnion<
             string,
-            z.Primitive,
-            z.ZodDiscriminatedUnionOption<string, z.Primitive>
+            z.ZodDiscriminatedUnionOption<string>[]
           >
         )._def.discriminator,
       },
       oneOf: Array.from(
         (
-          zodRef as z.ZodDiscriminatedUnion<
+          zodRef as  z.ZodDiscriminatedUnion<
             string,
-            z.Primitive,
-            z.ZodDiscriminatedUnionOption<string, z.Primitive>
+            z.ZodDiscriminatedUnionOption<string>[]
           >
         )._def.options.values()
       ).map((schema) => generateSchema(schema, useOutput)),


### PR DESCRIPTION
Adds support for `zod@3.20.0`:
- The `ZodDiscriminatedUnion` type changed, only taking two arguments instead of 3.
- Lengths now have an `exactLength` field, and may not have a min or max.

Fixes support for (discriminated) unions when creating a nest DTO. Previously Typescript would give the error `Base constructor return type <X> is not an object type or intersection of object types with statically known members.`. Using `type-fest` we merge these types together into a single interface instead of a union when creating the nest DTO.