### PR TITLE
feat(zod-mock): Make union (incl. discriminated), enum (incl. native), and regex generation deterministic

### DIFF
--- a/packages/zod-mock/src/lib/zod-mock.spec.ts
+++ b/packages/zod-mock/src/lib/zod-mock.spec.ts
@@ -537,6 +537,37 @@ describe('zod-mock', () => {
     expect(first).toEqual(second);
   });
 
+  it('Options seed value will return the same union & enum members', () => {
+    enum NativeEnum {
+      a = 1,
+      b = 2,
+    }
+
+    const schema = z.object({
+      theme: z.enum([`light`, `dark`]),
+      nativeEnum: z.nativeEnum(NativeEnum),
+      union: z.union([z.literal('a'), z.literal('b')]),
+      discriminatedUnion: z.discriminatedUnion('discriminator', [
+        z.object({ discriminator: z.literal('a'), a: z.boolean() }),
+        z.object({ discriminator: z.literal('b'), b: z.string() }),
+      ]),
+    });
+    const seed = 123;
+    const first = generateMock(schema, { seed });
+    const second = generateMock(schema, { seed });
+    expect(first).toEqual(second);
+  });
+
+  it('Options seed value will return the same generated regex values', () => {
+    const schema = z.object({
+      data: z.string().regex(/^[A-Z0-9+_.-]+@[A-Z0-9.-]+$/),
+    });
+    const seed = 123;
+    const first = generateMock(schema, { seed });
+    const second = generateMock(schema, { seed });
+    expect(first).toEqual(second);
+  });
+
   // it.only('Can use my own version of faker', () => {
   //   const schema = z.object({
   //     name: z.string(),


### PR DESCRIPTION
`zod-mock` already uses faker to make random array selections in some places, but I noticed it was using `Math.random()` for newer features, which isn’t seedable. This PR replicates the style of other parts of the codebase to randomly select union & enum members.

As a bonus, I also used `randexp`’s preferred method to replace their internal RNG (which is to just override the `randInt` method) with a seeded one. With this, as far as I can tell, all RNG functionality is seedable!

There’s a bug that concerns me about the way randomness is seeded in this library, however. Resetting the seed on every generation makes certain combinations impossible to achieve. Because `faker.mersenne` will return the same values after being reset, we end up selecting elements in the same regions of arrays. For example:

```ts
const schema = z.union([
  z.union([
    z.literal(1),
    z.literal(2),
  ]),
  z.union([
    z.literal(3),
    z.literal(4),
  ]),
])
```

This schema will only ever generate `1` and `4`, because the seeded RNG will only pick either `0` or `1` when first asked to generate an array index, and it’s ‘first’ asked to generate an array index twice consecutively as it recurses the schema (it will always generate `0` twice, or `1` twice). You can fix this by managing your own `faker` class, but it feels a bit weird. I don’t know what an idiomatic solution would be—probably either _not_ forwarding `seed` in recursive `generateMock` calls, or using a class to manage a single `faker` instance.

Also added passing tests for these pieces of functionality.

Please let me know what changes I should make otherwise! I am keen to rely on this library :)