### PR TITLE
feat: set additionalProperties to false if strict

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17589,7 +17589,7 @@
     },
     "packages/zod-mock": {
       "name": "@anatine/zod-mock",
-      "version": "3.8.0",
+      "version": "3.8.2",
       "license": "MIT",
       "dependencies": {
         "randexp": "^0.5.3"
@@ -17600,7 +17600,7 @@
     },
     "packages/zod-nestjs": {
       "name": "@anatine/zod-nestjs",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "MIT",
       "dependencies": {
         "@anatine/zod-openapi": "^1.10.0"
@@ -17614,7 +17614,7 @@
     },
     "packages/zod-openapi": {
       "name": "@anatine/zod-openapi",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "license": "MIT",
       "dependencies": {
         "ts-deepmerge": "^4.0.0"

--- a/packages/zod-openapi/src/lib/zod-openapi.spec.ts
+++ b/packages/zod-openapi/src/lib/zod-openapi.spec.ts
@@ -391,6 +391,31 @@ describe('zodOpenapi', () => {
     });
   });
 
+  it('should support `strict` on an object schema', () => {
+    const zodSchema = extendApi(
+      z
+        .object({
+          aString: z.string(),
+          aNumber: z.number(),
+        })
+        .strict(),
+      {
+        description: "Super strict",
+      }
+    );
+    const apiSchema = generateSchema(zodSchema);
+    expect(apiSchema).toEqual({
+      type: 'object',
+      required: ['aString', 'aNumber'],
+      properties: {
+        aString: { type: 'string' },
+        aNumber: { type: 'number' },
+      },
+      additionalProperties: false,
+      description: "Super strict",
+    });
+  });
+
   it('Testing large mixed schema', () => {
     enum Fruits {
       Apple,

--- a/packages/zod-openapi/src/lib/zod-openapi.ts
+++ b/packages/zod-openapi/src/lib/zod-openapi.ts
@@ -184,9 +184,11 @@ function parseObject({
     additionalProperties = generateSchema(zodRef._def.catchall, useOutput);
   else if (zodRef._def.unknownKeys === 'passthrough')
     additionalProperties = true;
+  else if (zodRef._def.unknownKeys === 'strict')
+    additionalProperties = false;
 
   // So that `undefined` values don't end up in the schema and be weird
-  additionalProperties = additionalProperties ? { additionalProperties } : {};
+  additionalProperties = additionalProperties != null ? { additionalProperties } : {};
 
   return merge(
     {


### PR DESCRIPTION
If `strict` is set, then `additionalProperties` will be set to `false`.

Fixes https://github.com/anatine/zod-plugins/issues/89