### PR TITLE
fix(zod-nestjs): set up nx project the same as zod-openapi

### DIFF
--- a/packages/zod-nestjs/project.json
+++ b/packages/zod-nestjs/project.json
@@ -5,7 +5,6 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "dependsOn": ["^build"],
       "executor": "@nrwl/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
@@ -24,7 +23,6 @@
       }
     },
     "test": {
-      "dependsOn": ["^build"],
       "executor": "@nrwl/jest:jest",
       "outputs": ["{workspaceRoot}/coverage/packages/zod-nestjs"],
       "options": {
@@ -51,10 +49,7 @@
     "publish": {
       "executor": "ngx-deploy-npm:deploy",
       "options": {
-        "access": "public",
-        "noBuild": true,
-        "tag": "${tag}",
-        "notes": "${notes}"
+        "access": "public"
       }
     }
   },


### PR DESCRIPTION
In October a couple commits were made that modified the nx project file for `zod-nestjs`.
(https://github.com/anatine/zod-plugins/commit/8e0e798943e541bfe0dcf6daafb299656a317738)
(https://github.com/anatine/zod-plugins/commit/6f20f44272fa2d8531b7b530695f537d0b2e6ed8)

It seems that may have caused this package to stop being published.

![image](https://user-images.githubusercontent.com/15315657/211439873-e326f533-b36f-4787-888f-b1b8dddff1f4.png)

```
❯ npm view @anatine/zod-nestjs time
{
  '1.8.0': '2022-10-05T18:44:43.639Z'
}
```

This commit just changes this project file to match the one in `zod-openapi`, as that is still publishing.