### PR TITLE
feat(zod-mock): Use custom faker instance everywhere when available

### DIFF
--- a/packages/zod-mock/src/lib/zod-mock.ts
+++ b/packages/zod-mock/src/lib/zod-mock.ts
@@ -8,7 +8,6 @@ import {
   ZodType,
   ZodString,
   ZodRecord,
-  number,
 } from 'zod';
 
 type FakerClass = typeof faker;

--- a/packages/zod-mock/src/lib/zod-mock.ts
+++ b/packages/zod-mock/src/lib/zod-mock.ts
@@ -8,6 +8,7 @@ import {
   ZodType,
   ZodString,
   ZodRecord,
+  number,
 } from 'zod';
 
 type FakerClass = typeof faker;
@@ -169,7 +170,7 @@ function parseString(
     sortedStringOptions.max = temp;
   }
 
-  const targetStringLength = faker.datatype.number(sortedStringOptions);
+  const targetStringLength = fakerInstance.datatype.number(sortedStringOptions);
   /**
    * Returns a random lorem word using `faker.lorem.word(length)`.
    * This method can return undefined for large word lengths. If undefined is returned
@@ -235,10 +236,43 @@ function parseString(
   let val = generator().toString();
   const delta = targetStringLength - val.length;
   if (stringOptions.min != null && val.length < stringOptions.min) {
-    val = val + faker.random.alpha(delta);
+    val = val + fakerInstance.random.alpha(delta);
   }
 
   return val.slice(0, stringOptions.max);
+}
+
+function parseBoolean(zodRef: z.ZodBoolean, options?: GenerateMockOptions) {
+  const fakerInstance = options?.faker || faker;
+  return fakerInstance.datatype.boolean();
+}
+
+function parseDate(zodRef: z.ZodDate, options?: GenerateMockOptions) {
+  const fakerInstance = options?.faker || faker;
+  const { checks = [] } = zodRef._def;
+  let min: number | undefined;
+  let max: number | undefined;
+
+  checks.forEach((item) => {
+    switch (item.kind) {
+      case 'min':
+        min = item.value;
+        break;
+      case 'max':
+        max = item.value;
+        break;
+    }
+  });
+
+  if (min !== undefined && max !== undefined) {
+    return fakerInstance.date.between(min, max);
+  } else if (min !== undefined && max === undefined) {
+    return fakerInstance.date.soon(undefined, min);
+  } else if (min === undefined && max !== undefined) {
+    return fakerInstance.date.recent(undefined, max);
+  } else {
+    return fakerInstance.date.soon();
+  }
 }
 
 function parseNumber(
@@ -454,8 +488,8 @@ const workerMap = {
   ZodString: parseString,
   ZodNumber: parseNumber,
   ZodBigInt: parseNumber,
-  ZodBoolean: () => faker.datatype.boolean(),
-  ZodDate: () => faker.date.soon(),
+  ZodBoolean: parseBoolean,
+  ZodDate: parseDate,
   ZodOptional: parseOptional,
   ZodNullable: parseOptional,
   ZodArray: parseArray,


### PR DESCRIPTION
There were a final handful of sources of non-seedable randomness in the package (in `string`, `boolean`, and `date`), which I’ve implemented in this PR. I also re-enabled and expanded the test for a customer faker instance.

This has the overall benefit of allowing fully deterministic generation, subject to 2 caveats (that I can tell). For `z.date()`, the library uses `faker.date.soon()` to generate dates, and for `z.string()` fields named `date` or `dateTime`, the library uses `faker.date.recent()` to generate an ISO string. These are reasonable trade-offs for default behaviour, because they will generate sensible-feeling dates. However, these depend on the current time, which is constantly increasing, and will lead to subtly different outputs on each regeneration.

To deal with this, I also added the ability to constrain `z.date()` generation with a minimum or maximum date (which uses `soon` and `recent` to generate plausible-seeming dates), or both (which uses `between`). There is no mechanism to do this for `z.string()`, however (although given the recent addition of `z.string().datetime()`, I suspect it will happen soon enough). This will change date generation, so I labelled this as a feature release, but I’m not sure if it could really be characterised as ‘breaking’.

Give us a shout if you’d prefer a different design—more than happy to implement it!