### PR TITLE
[zod-mock] ensure zod.string().datetime() maps to correct string generator

### DIFF
--- a/packages/zod-mock/src/lib/zod-mock.spec.ts
+++ b/packages/zod-mock/src/lib/zod-mock.spec.ts
@@ -133,6 +133,14 @@ describe('zod-mock', () => {
     expect(new Date(mockData.date).getTime()).not.toBeNaN();
   });
 
+  it("should correctly generate date strings for date validated strings", () => {
+    const schema = z.object({
+      dateString: z.string().datetime(),
+    });
+    const mockData = generateMock(schema);
+    expect(new Date(mockData.dateString).getTime()).not.toBeNaN()
+  });
+
   describe('when handling min and max string lengths', () => {
     const createSchema = (min: number, max: number) =>
       z.object({

--- a/packages/zod-mock/src/lib/zod-mock.ts
+++ b/packages/zod-mock/src/lib/zod-mock.ts
@@ -211,7 +211,7 @@ function parseString(
     (Object.keys(stringGenerators).find(
       (genKey) =>
         genKey.toLowerCase() === lowerCaseKeyName ||
-        checks.find((item) => item.kind === genKey)
+        checks.find((item) => item.kind.toUpperCase() === genKey.toUpperCase())
     ) as keyof typeof stringGenerators) || null;
 
   let generator: fakerFunction = defaultGenerator;


### PR DESCRIPTION
Currently if you provide a schema with `z.string().datetime()`, the mock generated is just a standard string. 
Expectation should be that it generates a string that would pass `datetime.parse(<mock string>)` as outlined [here](https://zod.dev/?id=datetime-validation).

Side effect of this approach is obviously that any keys in the schema that map into the [`stringGenerator`](https://github.com/anatine/zod-plugins/blob/a3d40f46382f9bb29e671229c16ec7a2e9cae5de/packages/zod-mock/src/lib/zod-mock.ts#L181) will do so in an ignore case fashion (eg: all these map to the same generator: ['datetime', 'dateTime', 'DATETIME']).  Afaik this shouldn't be an issue but if it is... the issue with `z.string().datetime()` could be resolved in other ways. 