### PR TITLE
feat(zod-mock): extend native enum to support const assertion

### DIFF
--- a/packages/zod-mock/src/lib/zod-mock.spec.ts
+++ b/packages/zod-mock/src/lib/zod-mock.spec.ts
@@ -413,6 +413,24 @@ describe('zod-mock', () => {
     expect(typeof value).toBe('string');
   });
 
+  it('ZodNativeEnum', () => {
+      enum NativeEnum {
+          a = 1,
+          b = 2,
+      }
+
+      const first = generateMock(z.nativeEnum(NativeEnum));
+      expect(first === 1 || first === 2);
+
+      const ConstAssertionEnum = {
+          a: 1,
+          b: 2
+      } as const;
+
+      const second = generateMock(z.nativeEnum(ConstAssertionEnum));
+      expect(second === 1 || second === 2);
+  });
+
   it('ZodFunction', () => {
     const func = generateMock(z.function(z.tuple([]), z.string()));
     expect(func).toBeTruthy();

--- a/packages/zod-mock/src/lib/zod-mock.ts
+++ b/packages/zod-mock/src/lib/zod-mock.ts
@@ -384,8 +384,7 @@ function parseNativeEnum(
 ) {
   const fakerInstance = options?.faker || faker;
   const { values } = zodRef._def;
-  const value = fakerInstance.helpers.arrayElement(values);
-  return values[value];
+  return fakerInstance.helpers.objectValue(values);
 }
 
 function parseLiteral(zodRef: z.ZodLiteral<any>) {


### PR DESCRIPTION
I wasn't sure why we've relied on arrayElement and then had to find the item in the array by accessing the list.
This implementation should cover both native enums and const assertions (it showed up as undefined in previous implementation).