### PR TITLE
fix(zod-nestjs) Nested required

### DIFF
--- a/packages/zod-nestjs/src/lib/create-zod-dto.spec.ts
+++ b/packages/zod-nestjs/src/lib/create-zod-dto.spec.ts
@@ -69,4 +69,23 @@ describe('zod-nesjs create-zod-dto', () => {
     const result = TestDto.create({kind: Kind.B, value: 'val'})
     expect(result).toEqual({ kind: Kind.B, value: 'val' });
   });
+
+  it('should handle nested requires', () => {
+    const petSchema = z.object({
+      animal: z.object({
+        legs: z.number(),
+      }),
+    });
+
+    class TestDto extends createZodDto(petSchema) {}
+
+    // @ts-ignore
+    expect(TestDto._OPENAPI_METADATA_FACTORY()).toEqual({
+      animal: {
+        type: 'object',
+        properties: { legs: { type: 'number', required: true } },
+        required: true,
+      },
+    });
+  });
 });


### PR DESCRIPTION
Hey there @Brian-McBride! Are you the point of contact for this repo? I've found that `createZodDto` isn't behaving as I'd expect with requiring nested properties.

```typescript
const petSchema = z.object({
  animal: z.object({
    legs: z.number(),
  }),
});

class TestDto extends createZodDto(petSchema) {}
```

Yields the following, only specifying that `animal` is required, but not `animal.legs`

```jsonc
// Expected
{
    "animal": {
        "type": "object",
        "properties": {
            "legs": {
                "type": "number",
                "required": true
            }
        },
        "required": true
    }
}

// Actual
{
    "animal": {
        "type": "object",
        "properties": {
            "legs": {
                "type": "number"
            }
        },
        "required": true
    }
}
```

I've thrown up an updated to `_OPENAPI_METADATA_FACTORY`, however I'm not seeing any usages of this function so I'm unsure the best method for testing this change outside of a unit test which accesses the method illegally. 

Its worth noting that existing consumers of createZodDto will be affected by this change. Some consumers of createZodDto might have worked around the issue by adding nullchecks before accessing fields, but code written using these DTOs for the submission of data might be affected as now "optional" fields will be required. Should we introduce a feature flag for this fix? Perhaps maybe an argument to `createZodDto` which enables recursion. That flag could be left disabled to support existing users, and can be turned on by default in the next major bump. 