### PR TITLE
feat(zod-mock): pass `zodRef` and `options` to generator function which defined in backupMocks

### DIFF
--- a/packages/zod-mock/src/lib/zod-mock.spec.ts
+++ b/packages/zod-mock/src/lib/zod-mock.spec.ts
@@ -367,6 +367,33 @@ describe('zod-mock', () => {
       expect(mock).toEqual(notUndefined());
     });
 
+    it('should use a user provided generator when a generator takes 2 arguments', () => {
+      // Given
+      const custom = z.custom<Date>((val) => val instanceof Date);
+      const anyDate = () => '2023-01-01T00:00:00.000Z';
+      const zodCustomBackupMock = (ref: z.ZodType): string | void => {
+        if (ref === (custom as z.ZodEffects<z.ZodAny>)._def.schema) {
+          return anyDate();
+        }
+      };
+
+      // When
+      const mock = generateMock(custom, {
+        backupMocks: { ZodAny: zodCustomBackupMock },
+      });
+
+      // Then
+      expect(mock).toEqual(anyDate())
+
+      // When
+      const mock2 = generateMock(z.custom(() => false), {
+        backupMocks: { ZodAny: zodCustomBackupMock },
+      })
+
+      // Then
+      expect(mock2).toBeUndefined()
+    })
+
     it('should work with objects and arrays', () => {
       const schema = z.object({
         data: z.array(z.undefined()).length(1),

--- a/packages/zod-mock/src/lib/zod-mock.ts
+++ b/packages/zod-mock/src/lib/zod-mock.ts
@@ -532,7 +532,7 @@ export interface GenerateMockOptions {
    * The functions in this map will only be used if this library
    * is unable to find an appropriate mocking function to use.
    */
-  backupMocks?: Record<string, () => any | undefined>;
+  backupMocks?: Record<string, (zodRef: AnyZodObject, options?: GenerateMockOptions) => any | undefined>;
 
   /**
    * How many entries to create for records
@@ -579,7 +579,7 @@ export function generateMock<T extends ZodTypeAny>(
       // workaround for unimplemented Zod types
       const generator = options.backupMocks[typeName];
       if (generator) {
-        return generator();
+        return generator(zodRef as never, options);
       }
     } else if (options?.throwOnUnknownType) {
       throw new ZodMockError(typeName);


### PR DESCRIPTION
It's a simple change, but one that opens up more possibilities for people using the library. feel free to close or review. thank you for good works.

Resolve #109