### PR TITLE
Updating faker-js lib to 8.0.x.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "tslib": "^2.4.1"
       },
       "devDependencies": {
-        "@faker-js/faker": "^7.6.0",
+        "@faker-js/faker": "^8.0.1",
         "@graphql-codegen/cli": "^2.16.1",
         "@graphql-codegen/typescript": "^2.8.5",
         "@graphql-codegen/typescript-operations": "^2.5.10",
@@ -2235,13 +2235,19 @@
       }
     },
     "node_modules/@faker-js/faker": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.6.0.tgz",
-      "integrity": "sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.0.1.tgz",
+      "integrity": "sha512-kbh5MenpTN9U0B4QcOI1NoTPlZHniSYQ3BHbhAnPjJGAmmFqxoxTE4sGdpy7ZOO9038DPGCuhXyMkjOr05uVwA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
       "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=6.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=6.14.13"
       }
     },
     "node_modules/@graphql-codegen/cli": {
@@ -20496,7 +20502,7 @@
     },
     "packages/zod-openapi": {
       "name": "@anatine/zod-openapi",
-      "version": "1.12.1",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "ts-deepmerge": "^4.0.0"
@@ -22054,9 +22060,9 @@
       }
     },
     "@faker-js/faker": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-7.6.0.tgz",
-      "integrity": "sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.0.1.tgz",
+      "integrity": "sha512-kbh5MenpTN9U0B4QcOI1NoTPlZHniSYQ3BHbhAnPjJGAmmFqxoxTE4sGdpy7ZOO9038DPGCuhXyMkjOr05uVwA==",
       "dev": true
     },
     "@graphql-codegen/cli": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "tslib": "^2.4.1"
   },
   "devDependencies": {
-    "@faker-js/faker": "^7.6.0",
+    "@faker-js/faker": "^8.0.1",
     "@graphql-codegen/cli": "^2.16.1",
     "@graphql-codegen/typescript": "^2.8.5",
     "@graphql-codegen/typescript-operations": "^2.5.10",

--- a/packages/zod-mock/src/lib/zod-mock.spec.ts
+++ b/packages/zod-mock/src/lib/zod-mock.spec.ts
@@ -63,7 +63,7 @@ describe('zod-mock', () => {
     const schema = z.object({
       // the following fields represent non function properties in Faker
       lorem: z.string(),
-      phone_number: z.string().min(10).optional(),
+      phoneNumber: z.string().min(10).optional(),
 
       // 'shuffle', located at `faker.helpers.shuffle`, is a function, but does not
       // produce the appropriate return type to match `fakerFunction`
@@ -76,7 +76,7 @@ describe('zod-mock', () => {
 
     const mockData = generateMock(schema);
     expect(typeof mockData.lorem).toEqual('string');
-    expect(typeof mockData.phone_number).toEqual('string');
+    expect(typeof mockData.phoneNumber).toEqual('string');
     expect(typeof mockData.shuffle).toEqual('string');
     expect(typeof mockData.seed).toEqual('string');
   });
@@ -441,21 +441,21 @@ describe('zod-mock', () => {
   });
 
   it('ZodNativeEnum', () => {
-      enum NativeEnum {
-          a = 1,
-          b = 2,
-      }
+    enum NativeEnum {
+      a = 1,
+      b = 2,
+    }
 
-      const first = generateMock(z.nativeEnum(NativeEnum));
-      expect(first === 1 || first === 2);
+    const first = generateMock(z.nativeEnum(NativeEnum));
+    expect(first === 1 || first === 2);
 
-      const ConstAssertionEnum = {
-          a: 1,
-          b: 2
-      } as const;
+    const ConstAssertionEnum = {
+      a: 1,
+      b: 2
+    } as const;
 
-      const second = generateMock(z.nativeEnum(ConstAssertionEnum));
-      expect(second === 1 || second === 2);
+    const second = generateMock(z.nativeEnum(ConstAssertionEnum));
+    expect(second === 1 || second === 2);
   });
 
   it('ZodFunction', () => {


### PR DESCRIPTION
Hello, 

Using faker-js lib and this lib on my project, I would love to upgrade to the last version aka 8.x.x
Using the last version and zod-mock at the current version sadly create a lot of warn message.

So I decided to upgrade directly this lib with this pull request :)

Everything seems mostly fine except this test "Avoid depreciations in strings". 
I tried to get it and fix it but I am really blocking at it.

Hope it easy to fix and we can quickly move this lib to the next version of faker-js 💪 
