### PR TITLE
Turn unions of literals into enums

### DIFF
--- a/packages/zod-openapi/src/lib/zod-openapi.spec.ts
+++ b/packages/zod-openapi/src/lib/zod-openapi.spec.ts
@@ -827,4 +827,35 @@ describe('zodOpenapi', () => {
       format: 'binary',
     });
   });
+
+  it('can summarize unions of zod literals as an enum', () => {
+    expect(generateSchema(z.union([z.literal('h'), z.literal('i')]))).toEqual({
+      type: 'string',
+      enum: ['h', 'i']
+    });
+
+    expect(generateSchema(z.union([z.literal(3), z.literal(4)]))).toEqual({
+      type: 'number',
+      enum: [3, 4]
+    });
+
+    // should this just remove the enum? true | false is exhaustive...
+    expect(generateSchema(z.union([z.literal(true), z.literal(false)]))).toEqual({
+      type: 'boolean',
+      enum: [true, false]
+    });
+
+    expect(generateSchema(z.union([z.literal(5), z.literal('i')]))).toEqual({
+      oneOf: [
+        {
+          type: 'number',
+          enum: [5]
+        },
+        {
+          type: 'string',
+          enum: ['i']
+        }
+      ]
+    });
+  })
 });

--- a/packages/zod-openapi/src/lib/zod-openapi.ts
+++ b/packages/zod-openapi/src/lib/zod-openapi.ts
@@ -390,7 +390,8 @@ function parseUnion({
   useOutput,
 }: ParsingArgs<z.ZodUnion<[z.ZodTypeAny, ...z.ZodTypeAny[]]>>): SchemaObject {
   const contents = zodRef._def.options;
-  if (contents.reduce((prev, content) => prev && content._def.typeName === "ZodLiteral", true)) {
+  if (contents.reduce((prev, content) => prev && content._def.typeName === 'ZodLiteral', true)) {
+    // special case to transform unions of literals into enums
     const literals = contents as unknown as z.ZodLiteral<OpenApiZodAny>[];
     const type = literals
       .reduce((prev, content) =>
@@ -411,6 +412,7 @@ function parseUnion({
       );
     }
   }
+
   return merge(
     {
       oneOf: contents.map((schema) => generateSchema(schema, useOutput)),


### PR DESCRIPTION
This is useful especially for integer literals. Here's where I noticed the current behavior:

```json
                          "type": {
                            "oneOf": [
                              { "type": "number", "enum": [1] },
                              { "type": "number", "enum": [2] },
                              { "type": "number", "enum": [3] },
                              { "type": "number", "enum": [4] },
                              { "type": "number", "enum": [5] },
                              { "type": "number", "enum": [6] },
                              { "type": "number", "enum": [7] },
                              { "type": "number", "enum": [8] },
                              { "type": "number", "enum": [9] },
                              { "type": "number", "enum": [10] },
                              { "type": "number", "enum": [11] }
                            ]
                          },
```

Debatably, it might be nicer to split cases like `z.union(z.literal(4), z.literal(5), z.literal("h"), z.literal("i"))` into 2 different groups and give those to the `oneOf`, which is really not possible the way I went around this. I suspect that case is significantly rarer, however.