### PR TITLE
Fix ZodNativeEnum mocks

### DIFF
--- a/packages/zod-mock/src/lib/zod-mock.spec.ts
+++ b/packages/zod-mock/src/lib/zod-mock.spec.ts
@@ -443,22 +443,36 @@ describe('zod-mock', () => {
     expect(typeof value).toBe('string');
   });
 
-  it('ZodNativeEnum', () => {
-    enum NativeEnum {
-      a = 1,
-      b = 2,
-    }
+  describe('ZodNativeEnum', () => {
+    it('numeric enum', () => {
+      enum NativeEnum {
+        a = 1,
+        b = 2,
+      }
 
-    const first = generateMock(z.nativeEnum(NativeEnum));
-    expect(first === 1 || first === 2);
+      const value = generateMock(z.nativeEnum(NativeEnum));
+      expect(value === 1 || value === 2).toBeTruthy();
+    });
 
-    const ConstAssertionEnum = {
-      a: 1,
-      b: 2,
-    } as const;
+    it('const assertion enum', () => {
+      const ConstAssertionEnum = {
+        a: 1,
+        b: 2,
+      } as const;
 
-    const second = generateMock(z.nativeEnum(ConstAssertionEnum));
-    expect(second === 1 || second === 2);
+      const value = generateMock(z.nativeEnum(ConstAssertionEnum));
+      expect(value === 1 || value === 2).toBeTruthy();
+    });
+
+    it('string enum', () => {
+      enum StringEnum {
+        a = 'A',
+        b = 'B',
+      }
+
+      const value = generateMock(z.nativeEnum(StringEnum));
+      expect(value === 'A' || value === 'B').toBeTruthy();
+    });
   });
 
   it('ZodFunction', () => {

--- a/packages/zod-mock/src/lib/zod-mock.ts
+++ b/packages/zod-mock/src/lib/zod-mock.ts
@@ -375,10 +375,7 @@ function parseMap(zodRef: z.ZodMap<never>, options?: GenerateMockOptions) {
   return results;
 }
 
-function parseEnum(
-  zodRef: z.ZodEnum<never> | z.ZodNativeEnum<never>,
-  options?: GenerateMockOptions
-) {
+function parseEnum(zodRef: z.ZodEnum<never>, options?: GenerateMockOptions) {
   const fakerInstance = options?.faker || faker;
   const values = zodRef._def.values as Array<z.infer<typeof zodRef>>;
   return fakerInstance.helpers.arrayElement(values);
@@ -400,8 +397,12 @@ function parseNativeEnum(
   options?: GenerateMockOptions
 ) {
   const fakerInstance = options?.faker || faker;
-  const { values } = zodRef._def;
-  return fakerInstance.helpers.objectValue(values);
+  /** See https://blog.oyam.dev/typescript-enum-values/ */
+  const enumObject = zodRef._def.values;
+  const values = Object.keys(enumObject ?? {})
+    .filter((key) => Number.isNaN(Number(key)))
+    .map((key) => enumObject[key]);
+  return fakerInstance.helpers.arrayElement(values);
 }
 
 function parseLiteral(zodRef: z.ZodLiteral<any>) {


### PR DESCRIPTION
This PR:
- Fixes the ZodNativeEnum tests which were a no-op (`expect()` were alone)
- Adds a test to properly check that both string and number enums are supported. The test suite was failing for ZodNativeEnum
- Changes `parseNativeEnum` to a version that supports both string and number enums