### PR TITLE
fix(zod-nestjs): resolve conflicting dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17983,7 +17983,7 @@
     },
     "packages/zod-mock": {
       "name": "@anatine/zod-mock",
-      "version": "3.12.1",
+      "version": "3.13.1",
       "license": "MIT",
       "dependencies": {
         "randexp": "^0.5.3"
@@ -17994,25 +17994,25 @@
     },
     "packages/zod-nestjs": {
       "name": "@anatine/zod-nestjs",
-      "version": "1.10.1",
+      "version": "2.0.1",
       "license": "MIT",
       "peerDependencies": {
         "@anatine/zod-openapi": "^1.10.0",
-        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0",
-        "@nestjs/swagger": "^6.0.0",
-        "openapi3-ts": "^2.0.0 || ^3.0.0",
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/swagger": "^6.0.0 || ^7.0.0",
+        "openapi3-ts": "^4.1.2",
         "zod": "^3.20.0"
       }
     },
     "packages/zod-openapi": {
       "name": "@anatine/zod-openapi",
-      "version": "1.14.2",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "ts-deepmerge": "^6.0.3"
       },
       "peerDependencies": {
-        "openapi3-ts": "^2.0.0 || ^3.0.0",
+        "openapi3-ts": "^4.1.2",
         "zod": "^3.20.0"
       }
     }

--- a/packages/zod-nestjs/package.json
+++ b/packages/zod-nestjs/package.json
@@ -26,7 +26,7 @@
     "zod": "^3.20.0",
     "openapi3-ts": "^4.1.2",
     "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
-    "@nestjs/swagger": "^6.0.0",
+    "@nestjs/swagger": "^6.0.0 || ^7.0.0",
     "@anatine/zod-openapi": "^1.10.0"
   }
 }


### PR DESCRIPTION
Fixes anatine/zod-plugins#140

When using @nestjs/common 10 you need at least @nestjs/swagger 7