### PR TITLE
Update package.json zod-openapi dependency

### DIFF
--- a/packages/zod-nestjs/package.json
+++ b/packages/zod-nestjs/package.json
@@ -27,6 +27,6 @@
     "openapi3-ts": "^4.1.2",
     "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
     "@nestjs/swagger": "^6.0.0 || ^7.0.0",
-    "@anatine/zod-openapi": "^1.10.0"
+    "@anatine/zod-openapi": "^2.0.1"
   }
 }


### PR DESCRIPTION
zod-openapi 1.10.0 references openapi3-ts@3.2.0, but zod-nestjs already references a newer version (4.1.2)