### PR TITLE
feat: parse ZodPipeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17983,7 +17983,7 @@
     },
     "packages/zod-mock": {
       "name": "@anatine/zod-mock",
-      "version": "3.13.1",
+      "version": "3.13.2",
       "license": "MIT",
       "dependencies": {
         "randexp": "^0.5.3"
@@ -17994,10 +17994,10 @@
     },
     "packages/zod-nestjs": {
       "name": "@anatine/zod-nestjs",
-      "version": "2.0.1",
+      "version": "2.0.3",
       "license": "MIT",
       "peerDependencies": {
-        "@anatine/zod-openapi": "^1.10.0",
+        "@anatine/zod-openapi": "^2.0.1",
         "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
         "@nestjs/swagger": "^6.0.0 || ^7.0.0",
         "openapi3-ts": "^4.1.2",
@@ -18006,7 +18006,7 @@
     },
     "packages/zod-openapi": {
       "name": "@anatine/zod-openapi",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "ts-deepmerge": "^6.0.3"

--- a/packages/zod-openapi/src/lib/zod-openapi.spec.ts
+++ b/packages/zod-openapi/src/lib/zod-openapi.spec.ts
@@ -931,4 +931,34 @@ describe('zodOpenapi', () => {
       ]
     });
   })
+
+  it('should work with ZodPipeline', () => {
+    expect(
+      generateSchema(
+        z
+          .string()
+          .regex(/^\d+$/)
+          .transform(Number)
+          .pipe(z.number().min(0).max(10))
+      )
+    ).toEqual({
+      type: 'string',
+      pattern: '^\\d+$',
+    } satisfies SchemaObject);
+
+    expect(
+      generateSchema(
+        z
+          .string()
+          .regex(/^\d+$/)
+          .transform(Number)
+          .pipe(z.number().min(0).max(10)),
+        true
+      )
+    ).toEqual({
+      type: 'number',
+      minimum: 0,
+      maximum: 10,
+    } satisfies SchemaObject);
+  });
 });

--- a/packages/zod-openapi/src/lib/zod-openapi.ts
+++ b/packages/zod-openapi/src/lib/zod-openapi.ts
@@ -511,6 +511,16 @@ function catchAllParser({
   );
 }
 
+function parsePipeline({
+  zodRef,
+  useOutput,
+}: ParsingArgs<z.ZodPipeline<never, never>>): SchemaObject {
+  if (useOutput) {
+    return generateSchema(zodRef._def.out, useOutput);
+  }
+  return generateSchema(zodRef._def.in, useOutput);
+}
+
 const workerMap = {
   ZodObject: parseObject,
   ZodRecord: parseRecord,
@@ -545,6 +555,7 @@ const workerMap = {
   ZodAny: catchAllParser,
   ZodUnknown: catchAllParser,
   ZodVoid: catchAllParser,
+  ZodPipeline: parsePipeline,
 };
 type WorkerKeys = keyof typeof workerMap;
 


### PR DESCRIPTION
I noticed that ZodPipeline is not currently supported.

If you have this schema for example:

```typescript
import { z } from 'zod';
import { generateSchema } from '@anatine/zod-openapi';

const schema = z
  .string()
  .regex(/^\d+$/)
  .transform(Number)
  .pipe(z.number().min(0).max(10));

const inputObjectSchema = generateSchema(schema);
// {}

const outputObjectSchema = generateSchema(schema, true);
// {}

```

After the changes of this PR:

```typescript
import { z } from 'zod';
import { generateSchema } from '@anatine/zod-openapi';

const schema = z
  .string()
  .regex(/^\d+$/)
  .transform(Number)
  .pipe(z.number().min(0).max(10));

const inputObjectSchema = generateSchema(schema);
// { type: 'string', pattern: '^\\d+$' }

const outputObjectSchema = generateSchema(schema, true);
// { type: 'number', minimum: 0, maximum: 10 }
```