### PR TITLE
Proposal: drop zod dependency in bundle by only importing zod types

### DIFF
--- a/packages/zod-openapi/src/lib/zod-extensions.ts
+++ b/packages/zod-openapi/src/lib/zod-extensions.ts
@@ -5,7 +5,7 @@ This code is heavily inspired by https://github.com/asteasolutions/zod-to-openap
 import { extendApi } from './zod-openapi';
 import {z} from "zod";
 import { SchemaObject } from "openapi3-ts/oas31";
-import {ZodTypeDef} from "zod/lib/types";
+import type {ZodTypeDef} from "zod/lib/types";
 
 
 declare module 'zod' {

--- a/packages/zod-openapi/src/lib/zod-openapi.ts
+++ b/packages/zod-openapi/src/lib/zod-openapi.ts
@@ -1,6 +1,6 @@
 import type { SchemaObject, SchemaObjectType } from 'openapi3-ts/oas31';
 import merge from 'ts-deepmerge';
-import { AnyZodObject, z, ZodTypeAny } from 'zod';
+import type { AnyZodObject, z, ZodTypeAny } from 'zod';
 
 type AnatineSchemaObject = SchemaObject & { hideDefinitions?: string[] };
 
@@ -201,7 +201,7 @@ function parseObject({
   // `catchall` obviates `strict`, `strip`, and `passthrough`
   if (
     !(
-      zodRef._def.catchall instanceof z.ZodNever ||
+      // zodRef._def.catchall instanceof z.ZodNever ||
       zodRef._def.catchall?._def.typeName === 'ZodNever'
     )
   )
@@ -221,9 +221,12 @@ function parseObject({
     return (
       !(
         item.isOptional() ||
-        item instanceof z.ZodDefault ||
+        // item instanceof z.ZodDefault ||
         item._def.typeName === 'ZodDefault'
-      ) && !(item instanceof z.ZodNever || item._def.typeName === 'ZodDefault')
+      ) && !(
+        // item instanceof z.ZodNever ||
+        item._def.typeName === 'ZodNever' ||
+        item._def.typeName === 'ZodDefault')
     );
   });
 
@@ -257,7 +260,9 @@ function parseRecord({
     {
       type: 'object' as SchemaObjectType,
       additionalProperties:
-        zodRef._def.valueType instanceof z.ZodUnknown
+        // @ts-expect-error This comparison appears to be unintentional because the types 'ZodFirstPartyTypeKind.ZodRecord' and '"ZodUnknown"' have no overlap.ts(2367)
+        zodRef._def.typeName === 'ZodUnknown'
+        // zodRef._def.valueType instanceof z.ZodUnknown
           ? {}
           : generateSchema(zodRef._def.valueType, useOutput),
     },


### PR DESCRIPTION
Hi!

Love this package, have been using it successfully in several projects, thank you so much for making it!


*TLDR*: Removing `instanceof` and just importing `zod` as types can reduce bundle sizes in some cases by 60kb. I think this is a worthwile gain for relatively little pain.

____

I've noticed that when used in combination with e.g. `ts-rest` or anything else that lets this into the bundle the size of the bundle increases dramatically because of the direct dependency on `zod`. 
Of course, anything that lets your packages into the bundle would probably also let `zod` into it, but because your package also explicitly imports `zod/lib/types` it confounds the issue.

I noticed that, barring 4 uses of `instanceof`, almost all the usage of `zod` in this package is on the type level. If we were able to `import type` instead of plain `import` `zod`, we would be able to drop `zod` from the `js` import, which would be nice.

So that is what I did, see below. I rather naively replaced the calls to `instanceof`, which leads to one test failing (one that checks for `z.record(z.unknown())`. I don't really know how to fix this, hence this being a draft PR.

See here a comparison of the different bundle sizes, checked by doing `npx banal dist/packages/zod-openapi/src/index.js`.

I've also tested this in a real world use case (https://github.com/tefkah/pubpub-client/tree/feat/integrate), using the dep from npm vs the built one in this PR. I can go into detail on how to do this, but the method is quite reliable (uses `yalc`).

As you can see, it saves a cool 60kb, nothing to sneeze at!

Of course, this whole problem can be solved by not including `zod` schemas in the bundle in the first place, but sometimes this is either unavoidable or desirable (say you want to do client-side validation). Having to separate out the openapi comments can be a bit of a pain, and this PR could be a relatively cheap way save some kbs.

# Concrete questions

I've marked the 4 places where `instanceof` is used and how I attempted to replace them. Could you have a look to see if this makes sense? At least one of them is not a valid replacement, and maybe it is impossible to truly replace `instanceof` here. Would love your thoughts!


# Comparisons

## Base package

### Before

<img width="1089" alt="image" src="https://github.com/anatine/zod-plugins/assets/21983833/9a00d769-03f4-4687-a4dc-d07833f75707">


### This PR 

<img width="1089" alt="image" src="https://github.com/anatine/zod-plugins/assets/21983833/c94248fd-5bfd-46a0-a47a-e79a5cf7fc71">

## Real world use case (pubpub-client)

### Before

<img width="1114" alt="image" src="https://github.com/anatine/zod-plugins/assets/21983833/a47185e2-fdac-4f6a-b05a-ca584a728d42">

#### Using this PR

<img width="1114" alt="image" src="https://github.com/anatine/zod-plugins/assets/21983833/f750142d-9d2e-4853-8528-d97c1406188a">
