### PR TITLE
Add `zod` as a `peerDependency` for `zod-mock`

### DIFF
--- a/packages/zod-mock/package.json
+++ b/packages/zod-mock/package.json
@@ -21,7 +21,8 @@
     "faker-js"
   ],
   "peerDependencies": {
-    "@faker-js/faker": "^7.0.0 || ^8.0.0"
+    "@faker-js/faker": "^7.0.0 || ^8.0.0",
+    "zod": "^3.21.4"
   },
   "dependencies": {
     "randexp": "^0.5.3"


### PR DESCRIPTION
In using `zod-mock` with [Yarn PnP](https://yarnpkg.com/features/pnp) in a monorepo, I've found that all return types for `generateMock` are `any` because `zod` itself can't be resolved. The same problem likely exists with other package managers that use module resolution strategies other than node module resolution.

This adds `zod` as a peerDependency so types work as expected. I took the `zod` version from the top level package.json was used. Perhaps a looser specification would be appropriate.

I've confirmed this fixes the problem for Yarn PnP in my monorepo.