### PR TITLE
fix(zod-openapi): do not mutate original schema with extendApi

### DIFF
--- a/packages/zod-openapi/src/lib/zod-openapi.spec.ts
+++ b/packages/zod-openapi/src/lib/zod-openapi.spec.ts
@@ -1027,6 +1027,14 @@ describe('zodOpenapi', () => {
         "type": "object",
       }
     `);
+  });
 
+  it('should not mutate the original schema', () => {
+    const s1 = extendApi(z.string(), { description: 's1' });
+    const s2 = extendApi(s1, { description: 's2' });
+    const apiSchema1 = generateSchema(s1);
+    const apiSchema2 = generateSchema(s2);
+    expect(apiSchema1.description).toEqual('s1');
+    expect(apiSchema2.description).toEqual('s2');
   });
 });

--- a/packages/zod-openapi/src/lib/zod-openapi.ts
+++ b/packages/zod-openapi/src/lib/zod-openapi.ts
@@ -23,8 +23,14 @@ export function extendApi<T extends OpenApiZodAny>(
   schema: T,
   schemaObject: AnatineSchemaObject = {}
 ): T {
-  schema.metaOpenApi = Object.assign(schema.metaOpenApi || {}, schemaObject);
-  return schema;
+  const This = (schema as any).constructor;
+  const newSchema = new This(schema._def);
+  newSchema.metaOpenApi = Object.assign(
+    {},
+    schema.metaOpenApi || {},
+    schemaObject
+  );
+  return newSchema;
 }
 
 function iterateZodObject({


### PR DESCRIPTION
I was trying to describe some fields of the same "primitive" type that I created with zod in different places of the API, but `extendApi` was overriding the description on that type instead of changing the description for that specific use case.

A solution is to not mutate the original schema with `extendApi`.