### PR TITLE
(WIP) zod-openapi: use defu instead of ts-deepmerge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@graphql-tools/utils": "^10.0.1",
         "axios": "^1.4.0",
         "randexp": "^0.5.3",
-        "ts-deepmerge": "^6.1.0",
         "tslib": "^2.6.0"
       },
       "devDependencies": {
@@ -8325,6 +8324,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/defu": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -16709,14 +16713,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ts-deepmerge": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-6.1.0.tgz",
-      "integrity": "sha512-YVJBhdIwYAZv6QoYz/mihpgbv+r0+QfQazTcSS6WXhQkbCxjTRoV+IOLtyArtz3au7xb+fPQVp1d7o5Qw1f1fg==",
-      "engines": {
-        "node": ">=14.13.1"
-      }
-    },
     "node_modules/ts-jest": {
       "version": "29.1.1",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.1.tgz",
@@ -17995,7 +17991,7 @@
     },
     "packages/zod-nestjs": {
       "name": "@anatine/zod-nestjs",
-      "version": "2.0.3",
+      "version": "2.0.5",
       "license": "MIT",
       "peerDependencies": {
         "@anatine/zod-openapi": "^2.0.1",
@@ -18007,10 +18003,10 @@
     },
     "packages/zod-openapi": {
       "name": "@anatine/zod-openapi",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "MIT",
       "dependencies": {
-        "ts-deepmerge": "^6.0.3"
+        "defu": "^6.1.4"
       },
       "peerDependencies": {
         "openapi3-ts": "^4.1.2",
@@ -18204,7 +18200,7 @@
     "@anatine/zod-openapi": {
       "version": "file:packages/zod-openapi",
       "requires": {
-        "ts-deepmerge": "^6.0.3"
+        "defu": "^6.1.4"
       }
     },
     "@angular-devkit/core": {
@@ -24414,6 +24410,11 @@
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
       "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
       "dev": true
+    },
+    "defu": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -30701,11 +30702,6 @@
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
       "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "dev": true
-    },
-    "ts-deepmerge": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-6.1.0.tgz",
-      "integrity": "sha512-YVJBhdIwYAZv6QoYz/mihpgbv+r0+QfQazTcSS6WXhQkbCxjTRoV+IOLtyArtz3au7xb+fPQVp1d7o5Qw1f1fg=="
     },
     "ts-jest": {
       "version": "29.1.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@graphql-tools/utils": "^10.0.1",
     "axios": "^1.4.0",
     "randexp": "^0.5.3",
-    "ts-deepmerge": "^6.1.0",
     "tslib": "^2.6.0"
   },
   "devDependencies": {
@@ -83,4 +82,3 @@
     "packages/**"
   ]
 }
-

--- a/packages/zod-openapi/package.json
+++ b/packages/zod-openapi/package.json
@@ -21,7 +21,7 @@
     "swagger"
   ],
   "dependencies": {
-    "ts-deepmerge": "^6.0.3"
+    "defu": "^6.1.4"
   },
   "peerDependencies": {
     "zod": "^3.20.0",

--- a/packages/zod-openapi/src/lib/zod-openapi.ts
+++ b/packages/zod-openapi/src/lib/zod-openapi.ts
@@ -1,5 +1,5 @@
 import type { SchemaObject, SchemaObjectType } from 'openapi3-ts/oas31';
-import merge from 'ts-deepmerge';
+import { defu as merge } from 'defu';
 import { AnyZodObject, z, ZodTypeAny } from 'zod';
 
 type AnatineSchemaObject = SchemaObject & { hideDefinitions?: string[] };


### PR DESCRIPTION
Hello!

I get `ts_deepmerge_1.default is not a function` errors when running a bundled version of my project with [workerd](https://github.com/cloudflare/workerd). The root cause of this is that the `merge` function from [ts-deepmerge](https://github.com/voodoocreation/ts-deepmerge)  is exported in a very weird way, and the bundler can't really figure out how to include it properly.

![image](https://github.com/anatine/zod-plugins/assets/3886658/22b83136-b52e-41e3-9768-36f70d86a200)

I propose a switch from [ts-deepmerge](https://github.com/voodoocreation/ts-deepmerge) to [defu](https://github.com/unjs/defu)

`defu` has a different order of priority for the passed parameters than `ts-deepmerge`. The left-most parameter  is the highest. Can this be an issue?

Thanks,
zsilbi