### PR TITLE
[zod-openapi] Merge additional OpenAPI definitions on ZodPipeline

### DIFF
--- a/packages/zod-openapi/src/lib/zod-openapi.spec.ts
+++ b/packages/zod-openapi/src/lib/zod-openapi.spec.ts
@@ -962,6 +962,48 @@ describe('zodOpenapi', () => {
     } satisfies SchemaObject);
   });
 
+  it('should work with ZodPipeline and additional extendApi', () => {
+    expect(
+      generateSchema(
+        extendApi(
+          z
+            .string()
+            .regex(/^\d+$/)
+            .transform(Number)
+            .pipe(z.number().min(0).max(10)),
+          {
+            description: 'Foo description',
+          }
+        )
+      )
+    ).toEqual({
+      type: 'string',
+      pattern: '^\\d+$',
+      description: 'Foo description',
+    } satisfies SchemaObject);
+
+    expect(
+      generateSchema(
+        extendApi(
+          z
+            .string()
+            .regex(/^\d+$/)
+            .transform(Number)
+            .pipe(z.number().min(0).max(10)),
+          {
+            description: 'Foo description',
+          }
+        ),
+        true
+      )
+    ).toEqual({
+      type: 'number',
+      minimum: 0,
+      maximum: 10,
+      description: 'Foo description',
+    } satisfies SchemaObject);
+  });
+
 
   it('should work with ZodTransform and correctly set nullable and optional', () => {
     type Type = string;

--- a/packages/zod-openapi/src/lib/zod-openapi.ts
+++ b/packages/zod-openapi/src/lib/zod-openapi.ts
@@ -527,13 +527,14 @@ function catchAllParser({
 }
 
 function parsePipeline({
+  schemas,
   zodRef,
   useOutput,
 }: ParsingArgs<z.ZodPipeline<never, never>>): SchemaObject {
-  if (useOutput) {
-    return generateSchema(zodRef._def.out, useOutput);
-  }
-  return generateSchema(zodRef._def.in, useOutput);
+  return merge(
+    generateSchema(useOutput ? zodRef._def.out : zodRef._def.in, useOutput),
+    ...schemas,
+  );
 }
 
 function parseReadonly({


### PR DESCRIPTION
Hi,

this PR fixes the situation when ZodPipeline has additional OpenAPI properties. Currently, they are ignored and it's impossible to add `description`  etc. to the documentation.