### PR TITLE
 Fix Handling of Optional Zod Fields with NestJS Swagger

### DIFF
--- a/packages/zod-nestjs/src/lib/create-zod-dto.spec.ts
+++ b/packages/zod-nestjs/src/lib/create-zod-dto.spec.ts
@@ -126,10 +126,11 @@ describe('zod-nesjs create-zod-dto', () => {
     const metadataFactory = getMetadataFactory(schema);
 
     const generatedSchema = metadataFactory();
-    const personName = generatedSchema?.person.properties?.name as SchemaObject30
-    const tags = generatedSchema?.person.properties?.tags as SchemaObject30
-    const tagsItems = tags.items as SchemaObject30
-    const tagName = tagsItems.properties?.name as SchemaObject30
+    const personName = generatedSchema?.person.properties
+      ?.name as SchemaObject30;
+    const tags = generatedSchema?.person.properties?.tags as SchemaObject30;
+    const tagsItems = tags.items as SchemaObject30;
+    const tagName = tagsItems.properties?.name as SchemaObject30;
 
     expect(generatedSchema).toBeDefined();
     expect(personName.type).toEqual('string');
@@ -149,6 +150,62 @@ describe('zod-nesjs create-zod-dto', () => {
     expect(generatedSchema).toBeDefined();
     expect(generatedSchema?.name.type).toEqual('string');
     expect(generatedSchema?.name.nullable).toBe(true);
+  });
+
+  it('should correct work with optional fields and make required fields false', () => {
+    const schema = z.object({
+      pagination: z
+        .object({
+          limit: z.number(),
+          offset: z.number(),
+        })
+        .optional(),
+      filter: z
+        .object({
+          category: z.string().uuid(),
+          userId: z.string().uuid(),
+        })
+        .optional(),
+      sort: z
+        .object({
+          field: z.string(),
+          order: z.string(),
+        })
+        .optional(),
+    });
+    const metadataFactory = getMetadataFactory(schema);
+
+    const generatedSchema = metadataFactory();
+    expect(generatedSchema?.pagination.required).toEqual(false);
+    expect(generatedSchema?.sort.required).toEqual(false);
+    expect(generatedSchema?.filter.required).toEqual(false);
+  });
+
+  it('should correct work with optional fields and make required field true and optional field false', () => {
+    const schema = z.object({
+      pagination: z
+        .object({
+          limit: z.number(),
+          offset: z.number(),
+        })
+        .optional(),
+      filter: z
+        .object({
+          category: z.string().uuid(),
+          userId: z.string().uuid(),
+        })
+        .optional(),
+      sort: z.object({
+        field: z.string(),
+        order: z.string(),
+      }),
+    });
+    const metadataFactory = getMetadataFactory(schema);
+
+    const generatedSchema = metadataFactory();
+    expect(generatedSchema?.pagination.required).toEqual(false);
+    expect(generatedSchema?.sort.required).toEqual(true);
+    expect(generatedSchema?.filter.required).toEqual(false);
   });
 });
 

--- a/packages/zod-nestjs/src/lib/create-zod-dto.ts
+++ b/packages/zod-nestjs/src/lib/create-zod-dto.ts
@@ -117,7 +117,7 @@ export const createZodDto = <T extends OpenApiZodAny>(
       )) {
         SchemaHolderClass.convertSchemaObject(
           subSchemaObject,
-          schemaObject.required?.includes(key)
+          schemaObject.required?.includes(key) ?? false
         );
       }
 
@@ -141,9 +141,9 @@ export const createZodDto = <T extends OpenApiZodAny>(
       if (Array.isArray(convertedSchemaObject.type)) {
         convertedSchemaObject.nullable =
           convertedSchemaObject.type.includes('null') || undefined;
-        convertedSchemaObject.type = convertedSchemaObject.type.find(
-          (item) => item !== 'null'
-        ) || 'string';
+        convertedSchemaObject.type =
+          convertedSchemaObject.type.find((item) => item !== 'null') ||
+          'string';
       } else if (convertedSchemaObject.type === 'null') {
         convertedSchemaObject.type = 'string'; // There ist no explicit null value in OpenAPI 3.0
         convertedSchemaObject.nullable = true;


### PR DESCRIPTION
Dear Anatine Team,

I've encountered an issue where optional object fields defined with Zod are incorrectly treated as required by NestJS Swagger. Upon investigation, I discovered that NestJS Swagger defaults to marking fields as required unless explicitly stated otherwise. This behavior leads to a discrepancy when integrating Zod schemas, as fields intended to be optional are handled as required.

**Issue Example:**

Consider the following schema, where both pagination and filter are intended as optional fields:

```typescript
const schema = z.object({
  pagination: z
    .object({
      limit: z.number(),
      offset: z.number(),
    })
    .optional(),
  filter: z
    .object({
      category: z.string().uuid(),
      userId: z.string().uuid(),
    })
    .optional(),
  sort: z.object({
    field: z.string(),
    order: z.string(),
  }),
});
```
In this scenario, NestJS Swagger incorrectly applies required: true to all fields, ignoring the optional designation provided by Zod.

**Proposed Solution:**

To address this issue, we must explicitly set required: false for fields where schemaObject.required is undefined. This ensures that our intent of marking fields as optional is accurately reflected in the generated Swagger documentation.

I believe this adjustment will enhance the integration compatibility between Zod and NestJS Swagger, ensuring that optional fields are correctly recognized and treated as such.

I look forward to your feedback on this proposed fix.