### PR TITLE
feat(zod-mock): support configure mock array length

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17807,7 +17807,7 @@
     },
     "packages/graphql-codegen-zod": {
       "name": "@anatine/graphql-codegen-zod",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/utils": "^8.8.0"
@@ -17831,7 +17831,7 @@
     },
     "packages/graphql-zod-validation": {
       "name": "@anatine/graphql-zod-validation",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@graphql-codegen/plugin-helpers": "^2.6.0",
@@ -17983,7 +17983,7 @@
     },
     "packages/zod-mock": {
       "name": "@anatine/zod-mock",
-      "version": "3.13.3",
+      "version": "3.13.4",
       "license": "MIT",
       "dependencies": {
         "randexp": "^0.5.3"
@@ -17995,7 +17995,7 @@
     },
     "packages/zod-nestjs": {
       "name": "@anatine/zod-nestjs",
-      "version": "2.0.3",
+      "version": "2.0.8",
       "license": "MIT",
       "peerDependencies": {
         "@anatine/zod-openapi": "^2.0.1",
@@ -18007,7 +18007,7 @@
     },
     "packages/zod-openapi": {
       "name": "@anatine/zod-openapi",
-      "version": "2.2.2",
+      "version": "2.2.5",
       "license": "MIT",
       "dependencies": {
         "ts-deepmerge": "^6.0.3"

--- a/packages/zod-mock/src/lib/zod-mock.ts
+++ b/packages/zod-mock/src/lib/zod-mock.ts
@@ -336,7 +336,10 @@ function parseArray(zodRef: z.ZodArray<never>, options?: GenerateMockOptions) {
   if (min > max) {
     min = max;
   }
-  const targetLength = fakerInstance.number.int({ min, max });
+  // if arrayItemsLength is already configured in options, use that
+  const targetLength =
+    options?.mapArrayItemsLength ?? fakerInstance.number.int({ min, max });
+
   const results: ZodTypeAny[] = [];
   for (let index = 0; index < targetLength; index++) {
     results.push(generateMock<ZodTypeAny>(zodRef._def.type, options));
@@ -570,6 +573,11 @@ export interface GenerateMockOptions {
    * How many entries to create for Maps
    */
   mapEntriesLength?: number;
+
+  /**
+   * How items to create for Arrays
+   */
+  mapArrayItemsLength?: number;
 
   /**
    * Set to true to throw an exception instead of returning undefined when encountering an unknown `ZodType`


### PR DESCRIPTION
This PR adds simple support for setting array length when generating a list of items.

This is useful to create sample data (for example empty list, or paginated list) in storybook