### PR TITLE
Bring back support for Open API v3.0

### DIFF
--- a/apps/example/src/main.spec.ts
+++ b/apps/example/src/main.spec.ts
@@ -59,7 +59,7 @@ describe('Cats', () => {
   //   console.log(inspect(body, false, 10, true));
   // });
 
-  it(`Swagger Test`, () => {
+  it(`Swagger Test`, async () => {
     return request(app.getHttpServer())
       .get('/api-json')
       .set('Accept', 'application/json')
@@ -163,11 +163,11 @@ describe('Cats', () => {
         components: {
           schemas: {
             GetCatsDto: {
-              type: ['object'],
+              type: 'object',
               properties: {
                 cats: {
-                  type: ['array'],
-                  items: { type: ['string'] },
+                  type: 'array',
+                  items: { type: 'string' },
                   description: 'List of cats',
                 },
               },
@@ -175,30 +175,30 @@ describe('Cats', () => {
               title: 'Get Cat Response',
             },
             CatDto: {
-              type: ['object'],
+              type: 'object',
               properties: {
-                name: { type: ['string'] },
-                age: { type: ['number'] },
-                breed: { type: ['string'] },
+                name: { type: 'string' },
+                age: { type: 'number' },
+                breed: { type: 'string' },
               },
               required: ['name', 'age', 'breed'],
               title: 'Cat',
               description: 'A cat',
             },
             CreateCatResponseDto: {
-              type: ['object'],
+              type: 'object',
               properties: {
-                success: { type: ['boolean'] },
-                message: { type: ['string'] },
-                name: { type: ['string'] },
+                success: { type: 'boolean' },
+                message: { type: 'string' },
+                name: { type: 'string' },
               },
               required: ['success', 'message', 'name'],
             },
             UpdateCatDto: {
-              type: ['object'],
+              type: 'object',
               properties: {
-                age: { type: ['number'] },
-                breed: { type: ['string'] },
+                age: { type: 'number' },
+                breed: { type: 'string' },
               },
               required: ['age', 'breed'],
             },

--- a/packages/zod-openapi/src/lib/zod-openapi.spec.ts
+++ b/packages/zod-openapi/src/lib/zod-openapi.spec.ts
@@ -37,6 +37,36 @@ describe('zodOpenapi', () => {
     });
   });
 
+  it('should support basic primitives for OpenAPI v3.0', () => {
+    const zodSchema = extendApi(
+      z.object({
+        aString: z.string().describe('A test string').optional(),
+        aNumber: z.number().optional(),
+        aBigInt: z.bigint(),
+        aBoolean: z.boolean(),
+        aDate: z.date(),
+      }),
+      {
+        description: `Primitives also testing overwriting of "required"`,
+        required: ['aNumber'], // All schema settings "merge"
+      }
+    );
+    const apiSchema = generateSchema(zodSchema, false, '3.0');
+
+    expect(apiSchema).toEqual({
+      type: 'object',
+      properties: {
+        aString: { description: 'A test string', type: 'string' },
+        aNumber: { type: 'number' },
+        aBigInt: { type: 'integer', format: 'int64' },
+        aBoolean: { type: 'boolean' },
+        aDate: { type: 'string', format: 'date-time' },
+      },
+      required: ['aBigInt', 'aBoolean', 'aDate', 'aNumber'],
+      description: 'Primitives also testing overwriting of "required"',
+    });
+  });
+
   it('should support empty types', () => {
     const zodSchema = extendApi(
       z.object({


### PR DESCRIPTION
Hey and thank you for a very nice project! It helps us a lot.

As mentioned in issue #192 version 2.2.4 of `@anatine/zod-openapi` introduced support for OpenAPI v3.1. But by doing so it also dropped support for v3.0 it seems.
I should mention that I am not an expert in the OpenAPI spec, so I can't tell what broke other than that 3.0 only supports `type` as a string union, not an array,
which seems to be supported in 3.1 and implemented in this package.

I've seen the discussions around supporting 3.1 and acknowledge that it is needed. But the fact is that this change broke the integration with NestJS's swagger
implementation which is still emitting 3.0 schemas. And this was introduced as a patch release, and not a major.

My proposal is to support both of the specs together by introducing a new paramater to `generateSchema` – `openApiVersion` which can be either `'3.0' | '3.1'`.
To not break anyone already relying on the 3.1 support of `generateSchema` I decided to set the default to 3.1.

But for `patchNestSwagger` I decided to set the default to 3.0 as to not break support for NestJS's swagger module.

Please let me know what you think about this change and if you see another solution that might be better suited. Also let me know if you want me to add more tests
to validate the 3.0 behaviour.

Fixes #192
