### PR TITLE
[zod-mock] Fix parseString

### DIFF
--- a/packages/zod-mock/src/lib/zod-mock.spec.ts
+++ b/packages/zod-mock/src/lib/zod-mock.spec.ts
@@ -113,6 +113,22 @@ describe('zod-mock', () => {
     return;
   });
 
+  it('Should manually mock string key names to set values when the validation has regex', () => {
+    const schema = z.object({
+      telephone: z.string().regex(/^\+[1-9]\d{1,14}$/)
+    });
+
+    const stringMap = {
+      telephone: () => '+919367788755',
+    };
+
+    const mockData = generateMock(schema, { stringMap });
+
+    expect(mockData.telephone).toEqual('+919367788755');
+
+    return;
+  });
+
   it('should convert values produced by Faker to string when the schema type is string.', () => {
     const schema = z.object({
       number: z.string(),

--- a/packages/zod-mock/src/lib/zod-mock.ts
+++ b/packages/zod-mock/src/lib/zod-mock.ts
@@ -125,6 +125,15 @@ function parseString(
   zodRef: z.ZodString,
   options?: GenerateMockOptions
 ): string | number | boolean {
+  // Prioritize user provided generators.
+  if (options?.keyName && options.stringMap) {
+    // min/max length handling is not applied here
+    const generator = options.stringMap[options.keyName];
+    if (generator) {
+      return generator();
+    }
+  }
+
   const fakerInstance = options?.faker || faker;
   const { checks = [] } = zodRef._def;
 
@@ -142,14 +151,6 @@ function parseString(
   }
 
   const lowerCaseKeyName = options?.keyName?.toLowerCase();
-  // Prioritize user provided generators.
-  if (options?.keyName && options.stringMap) {
-    // min/max length handling is not applied here
-    const generator = options.stringMap[options.keyName];
-    if (generator) {
-      return generator();
-    }
-  }
   const stringOptions: {
     min?: number;
     max?: number;


### PR DESCRIPTION
zod-mock can override string mocks with [the stringMap option](https://github.com/anatine/zod-plugins/tree/main/packages/zod-mock#overriding-string-mocks).
However, this doesn't work when the validation has regex (e.g. `z.string().regex(/^\+[1-9]\d{1,14}$/)`) since the regexCheck logic is placed before the stringMap logic.
This PR will fix the issue.