### PR TITLE
🚀 feat(zod-mock): update date generator for dateTime handling in mock…

### DIFF
--- a/packages/zod-mock/src/lib/zod-mock.ts
+++ b/packages/zod-mock/src/lib/zod-mock.ts
@@ -195,7 +195,8 @@ function parseString(
     targetStringLength > 10
       ? fakerInstance.lorem.word()
       : fakerInstance.lorem.word({ length: targetStringLength });
-  const dateGenerator = () => fakerInstance.date.recent().toISOString();
+  const dateGenerator = () => fakerInstance.date.recent().toISOString().substring(0,10);
+  const datetimeGenerator = () => fakerInstance.date.recent().toISOString();
   const stringGenerators = {
     default: defaultGenerator,
     email: fakerInstance.internet.exampleEmail,
@@ -204,7 +205,7 @@ function parseString(
     url: fakerInstance.internet.url,
     name: fakerInstance.person.fullName,
     date: dateGenerator,
-    dateTime: dateGenerator,
+    dateTime: datetimeGenerator,
     colorHex: fakerInstance.internet.color,
     color: fakerInstance.internet.color,
     backgroundColor: fakerInstance.internet.color,


### PR DESCRIPTION
Fixes #213 

Since Zod 3.23, according to [Zod documentation](https://zod.dev/?id=dates)

The `z.string().date()` method validates strings in the format `YYYY-MM-DD`.

```
const date = z.string().date();

date.parse("2020-01-01"); // pass
date.parse("2020-1-1"); // fail
date.parse("2020-01-32"); // fail
```

The z.string().datetime() method enforces ISO 8601

```
const datetime = z.string().datetime();

datetime.parse("2020-01-01T00:00:00Z"); // pass
datetime.parse("2020-01-01T00:00:00.123Z"); // pass
datetime.parse("2020-01-01T00:00:00.123456Z"); // pass (arbitrary precision)
datetime.parse("2020-01-01T00:00:00+02:00"); // fail (no offsets allowed)
```