### PR TITLE
Fix handling of `null`s, nullables, and exclusive{Min,Max} for OpenAPI 3.0

### DIFF
--- a/packages/zod-openapi/src/lib/zod-openapi.spec.ts
+++ b/packages/zod-openapi/src/lib/zod-openapi.spec.ts
@@ -45,6 +45,7 @@ describe('zodOpenapi', () => {
         aBigInt: z.bigint(),
         aBoolean: z.boolean(),
         aDate: z.date(),
+        aNullableString: z.string().nullable(),
       }),
       {
         description: `Primitives also testing overwriting of "required"`,
@@ -61,8 +62,9 @@ describe('zodOpenapi', () => {
         aBigInt: { type: 'integer', format: 'int64' },
         aBoolean: { type: 'boolean' },
         aDate: { type: 'string', format: 'date-time' },
+        aNullableString: { type: 'string', nullable: true },
       },
-      required: ['aBigInt', 'aBoolean', 'aDate', 'aNumber'],
+      required: ['aBigInt', 'aBoolean', 'aDate', 'aNullableString', 'aNumber'],
       description: 'Primitives also testing overwriting of "required"',
     });
   });

--- a/packages/zod-openapi/src/lib/zod-openapi.spec.ts
+++ b/packages/zod-openapi/src/lib/zod-openapi.spec.ts
@@ -47,6 +47,8 @@ describe('zodOpenapi', () => {
         aDate: z.date(),
         aNullableString: z.string().nullable(),
         aUnionIncludingNull: z.union([z.string(), z.null(), z.number()]),
+        aNumberMin: z.number().min(3).optional(),
+        aNumberGt: z.number().gt(5).optional(),
       }),
       {
         description: `Primitives also testing overwriting of "required"`,
@@ -65,6 +67,8 @@ describe('zodOpenapi', () => {
         aDate: { type: 'string', format: 'date-time' },
         aNullableString: { type: 'string', nullable: true },
         aUnionIncludingNull: { oneOf: [{ type: 'string' }, { type: 'number' }], nullable: true },
+        aNumberMin: { type: 'number', minimum: 3 },
+        aNumberGt: { type: 'number', minimum: 5, exclusiveMinimum: true },
       },
       required: ['aBigInt', 'aBoolean', 'aDate', 'aNullableString', 'aUnionIncludingNull', 'aNumber'],
       description: 'Primitives also testing overwriting of "required"',

--- a/packages/zod-openapi/src/lib/zod-openapi.spec.ts
+++ b/packages/zod-openapi/src/lib/zod-openapi.spec.ts
@@ -46,6 +46,7 @@ describe('zodOpenapi', () => {
         aBoolean: z.boolean(),
         aDate: z.date(),
         aNullableString: z.string().nullable(),
+        aUnionIncludingNull: z.union([z.string(), z.null(), z.number()]),
       }),
       {
         description: `Primitives also testing overwriting of "required"`,
@@ -63,8 +64,9 @@ describe('zodOpenapi', () => {
         aBoolean: { type: 'boolean' },
         aDate: { type: 'string', format: 'date-time' },
         aNullableString: { type: 'string', nullable: true },
+        aUnionIncludingNull: { oneOf: [{ type: 'string' }, { type: 'number' }], nullable: true },
       },
-      required: ['aBigInt', 'aBoolean', 'aDate', 'aNullableString', 'aNumber'],
+      required: ['aBigInt', 'aBoolean', 'aDate', 'aNullableString', 'aUnionIncludingNull', 'aNumber'],
       description: 'Primitives also testing overwriting of "required"',
     });
   });

--- a/packages/zod-openapi/src/lib/zod-openapi.ts
+++ b/packages/zod-openapi/src/lib/zod-openapi.ts
@@ -496,10 +496,17 @@ function parseUnion({
     }
   }
 
+  const oneOfContents =
+    openApiVersion === '3.0'
+      ? contents.filter((content) => content._def.typeName !== 'ZodNull')
+      : contents;
+  const contentsHasNull = contents.length != oneOfContents.length;
+
   return merge(
     {
-      oneOf: contents.map((schema) => generateSchema(schema, useOutput, openApiVersion)),
+      oneOf: oneOfContents.map((schema) => generateSchema(schema, useOutput, openApiVersion)),
     },
+    contentsHasNull ? { nullable: true } : {},
     zodRef.description ? { description: zodRef.description } : {},
     ...schemas
   );

--- a/packages/zod-openapi/src/lib/zod-openapi.ts
+++ b/packages/zod-openapi/src/lib/zod-openapi.ts
@@ -170,12 +170,30 @@ function parseNumber({
   checks.forEach((item) => {
     switch (item.kind) {
       case 'max':
-        if (item.inclusive) baseSchema.maximum = item.value;
-        else baseSchema.exclusiveMaximum = item.value;
+        if (item.inclusive || openApiVersion === '3.0') {
+          baseSchema.maximum = item.value;
+        }
+        if (!item.inclusive) {
+          if (openApiVersion === '3.0') {
+            // exclusiveMaximum has conflicting types in oas31 and oas30
+            baseSchema.exclusiveMaximum = true as unknown as number;
+          } else {
+            baseSchema.exclusiveMaximum = item.value;
+          }
+        }
         break;
       case 'min':
-        if (item.inclusive) baseSchema.minimum = item.value;
-        else baseSchema.exclusiveMinimum = item.value;
+        if (item.inclusive || openApiVersion === '3.0') {
+          baseSchema.minimum = item.value;
+        }
+        if (!item.inclusive) {
+          if (openApiVersion === '3.0') {
+            // exclusiveMinimum has conflicting types in oas31 and oas30
+            baseSchema.exclusiveMinimum = true as unknown as number;
+          } else {
+            baseSchema.exclusiveMinimum = item.value;
+          }
+        }
         break;
       case 'int':
         baseSchema.type = typeFormat('integer', openApiVersion);

--- a/packages/zod-openapi/src/lib/zod-openapi.ts
+++ b/packages/zod-openapi/src/lib/zod-openapi.ts
@@ -359,7 +359,9 @@ function parseNullable({
   const schema = generateSchema(zodRef.unwrap(), useOutput, openApiVersion);
   return merge(
     schema,
-    { type: typeFormat('null', openApiVersion) },
+    openApiVersion === '3.0'
+      ? { nullable: true }
+      : { type: typeFormat('null', openApiVersion) },
     zodRef.description ? { description: zodRef.description } : {},
     ...schemas
   );


### PR DESCRIPTION
Fixes #220 #211 #228 #212

This adds OpenAPI 3.0-specific logic so that the correct 3.0 results are generated.

Looking beyond the somewhat liberal sprinkling of 3.0-vs-3.1 conditionals, I had to add some typecasts since the base schema is incompatible in 3.0 vs 3.1 for exclusive values. I do wonder if long term, the 3.0 and 3.1 functions should be split out entirely.