### PR TITLE
fix: Use AnatineSchemaObject in openapi extension method

### DIFF
--- a/packages/zod-openapi/src/lib/zod-extensions.spec.ts
+++ b/packages/zod-openapi/src/lib/zod-extensions.spec.ts
@@ -12,8 +12,11 @@ describe('Zod Extensions', () => {
     const schema = z.object({
       one: z.string().openapi({examples: ['oneOne']}),
       two: z.number(),
-
-    }).openapi({examples: [{one: 'oneOne', two: 42}]})
+      three: z.number().optional(),
+    }).openapi({
+      examples: [{one: 'oneOne', two: 42}],
+      hideDefinitions: ['three']
+    })
 
     const apiSchema = generateSchema(schema);
 
@@ -35,7 +38,8 @@ describe('Zod Extensions', () => {
         "one",
         "two"
       ],
-      "type": ["object"]
+      "type": ["object"],
+      "hideDefinitions": ["three"],
     })
   })
 

--- a/packages/zod-openapi/src/lib/zod-extensions.ts
+++ b/packages/zod-openapi/src/lib/zod-extensions.ts
@@ -2,9 +2,8 @@
 This code is heavily inspired by https://github.com/asteasolutions/zod-to-openapi/blob/master/src/zod-extensions.ts
  */
 
-import { extendApi } from './zod-openapi';
+import { AnatineSchemaObject, extendApi } from './zod-openapi';
 import {z} from "zod";
-import { SchemaObject } from "openapi3-ts/oas31";
 import {ZodTypeDef} from "zod";
 
 
@@ -13,7 +12,7 @@ declare module 'zod' {
   interface ZodSchema<Output = any, Def extends ZodTypeDef = ZodTypeDef, Input = Output> {
     openapi<T extends ZodSchema<Output, Def, Input>>(
       this: T,
-      metadata: Partial<SchemaObject>
+      metadata: Partial<AnatineSchemaObject>
     ): T;
   }
 }
@@ -27,7 +26,7 @@ export function extendZodWithOpenApi(zod: typeof z, forceOverride = false) {
   }
 
   zod.ZodSchema.prototype.openapi = function (
-    metadata?: Partial<SchemaObject>
+    metadata?: Partial<AnatineSchemaObject>
   ) {
       return extendApi(this, metadata)
   }

--- a/packages/zod-openapi/src/lib/zod-openapi.ts
+++ b/packages/zod-openapi/src/lib/zod-openapi.ts
@@ -2,7 +2,7 @@ import type { SchemaObject, SchemaObjectType } from 'openapi3-ts/oas31';
 import merge from 'ts-deepmerge';
 import { AnyZodObject, z, ZodTypeAny } from 'zod';
 
-type AnatineSchemaObject = SchemaObject & { hideDefinitions?: string[] };
+export type AnatineSchemaObject = SchemaObject & { hideDefinitions?: string[] };
 
 export interface OpenApiZodAny extends ZodTypeAny {
   metaOpenApi?: AnatineSchemaObject | AnatineSchemaObject[];
@@ -312,7 +312,7 @@ function parseBigInt({
   openApiVersion,
 }: ParsingArgs<z.ZodBigInt>): SchemaObject {
   return merge(
-    { 
+    {
       type: typeFormat('integer', openApiVersion),
       format: 'int64'
     },


### PR DESCRIPTION
This change allows `hideDefinition` use directly in `.openapi()` extension method.

```ts
z.object({
  one: z.string(),
  two: z.number()
})
.openapi({
  hideDefinition: ['two']
})
```

Example above do not work right now, as `hideDefinition` is specified as an additional property on `AnatineSchemaObject`, not `SchemaObject` itself.