### PR TITLE
feat(zod-mock): add support for readonly fields

### DIFF
--- a/packages/zod-mock/src/lib/zod-mock.spec.ts
+++ b/packages/zod-mock/src/lib/zod-mock.spec.ts
@@ -32,6 +32,7 @@ describe('zod-mock', () => {
         z.object({ discriminator: z.literal('a'), a: z.boolean() }),
         z.object({ discriminator: z.literal('b'), b: z.string() }),
       ]),
+      readonly: z.boolean().readonly(),
     });
 
     const mockData = generateMock(schema);
@@ -58,6 +59,7 @@ describe('zod-mock', () => {
     expect(mockData.set).toBeTruthy();
     expect(mockData.map).toBeTruthy();
     expect(mockData.discriminatedUnion).toBeTruthy();
+    expect(typeof mockData.readonly).toEqual('boolean');
   });
 
   it('should generate mock data of the appropriate type when the field names overlap Faker properties that are not valid functions', () => {

--- a/packages/zod-mock/src/lib/zod-mock.ts
+++ b/packages/zod-mock/src/lib/zod-mock.ts
@@ -536,6 +536,13 @@ function parseLazy(
   return generateMock(zodRef._def.getter(), options);
 }
 
+function parseReadonly(
+  zodRef: z.ZodReadonly<ZodTypeAny>,
+  options?: GenerateMockOptions
+) {
+  return generateMock(zodRef._def.innerType, options);
+}
+
 const workerMap = {
   ZodObject: parseObject,
   ZodRecord: parseRecord,
@@ -565,6 +572,7 @@ const workerMap = {
   ZodBranded: parseBranded,
   ZodNull: () => null,
   ZodNaN: () => NaN,
+  ZodReadonly: parseReadonly,
 };
 
 type WorkerKeys = keyof typeof workerMap;


### PR DESCRIPTION
This change adds support for zod readonly fields. before this change the innertype was ignored and the value was always set to undefined.

generateMock now generates the correct underlaying type.

fixes #195