### PR TITLE
fix(zod-mock): update peer dependency range for @faker-js/faker to include ^9.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17989,7 +17989,7 @@
         "randexp": "^0.5.3"
       },
       "peerDependencies": {
-        "@faker-js/faker": "^7.0.0 || ^8.0.0",
+        "@faker-js/faker": "^7.0.0 || ^8.0.0 || ^9.0.0",
         "zod": "^3.21.4"
       }
     },

--- a/packages/zod-mock/package.json
+++ b/packages/zod-mock/package.json
@@ -21,7 +21,7 @@
     "faker-js"
   ],
   "peerDependencies": {
-    "@faker-js/faker": "^7.0.0 || ^8.0.0",
+    "@faker-js/faker": "^7.0.0 || ^8.0.0 || ^9.0.0",
     "zod": "^3.21.4"
   },
   "dependencies": {


### PR DESCRIPTION
fixes #240 by adding faker 9 to the peer dependency range