### PR TITLE
[zod-nestjs] Add custom exception for zod validation failures

### DIFF
--- a/packages/zod-nestjs/README.md
+++ b/packages/zod-nestjs/README.md
@@ -136,6 +136,20 @@ export class CatsController {
 
 NOTE: Responses have to use the `ApiCreatedResponse` decorator when using the `@nestjs/swagger` module.
 
+#### Advanced Error Handling with ZodValidationException
+
+By default, `ZodValidationPipe` throws standard `BadRequestException` when validation fails. If you need access to the original Zod error information for custom error handling, you can enable `useZodValidationException`:
+
+```ts
+// Enable ZodValidationException for detailed error information
+@UsePipes(new ZodValidationPipe({ useZodValidationException: true }))
+```
+
+**Available methods on ZodValidationException:**
+
+- `getZodError()`: Returns the original `ZodError` object
+- `getFormattedZodError()`: Returns a formatted object with field paths as keys and error messages as values
+
 ### Set up your app
 
 Patch the swagger so that it can use Zod types before you create the document.

--- a/packages/zod-nestjs/src/index.ts
+++ b/packages/zod-nestjs/src/index.ts
@@ -1,3 +1,4 @@
 export * from './lib/create-zod-dto';
 export * from './lib/zod-validation-pipe';
 export * from './lib/patch-nest-swagger';
+export { ZodValidationException } from './lib/exception';

--- a/packages/zod-nestjs/src/lib/exception.spec.ts
+++ b/packages/zod-nestjs/src/lib/exception.spec.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+import { ZodValidationException } from './exception';
+
+describe('ZodValidationException', () => {
+  const schema = z.object({ foo: z.string().min(3) });
+  const invalidInput = { foo: 'ab' };
+
+  it('should extend BadRequestException and include original ZodError', () => {
+    const parseResult = schema.safeParse(invalidInput);
+    if (parseResult.success) {
+      throw new Error('Expected parseResult to be error');
+    }
+    const exception = new ZodValidationException(parseResult.error, 'Custom message');
+    // instanceof check
+    expect(exception).toBeInstanceOf(ZodValidationException);
+    // Prefer custom message for exception.message
+    expect(exception.message).toEqual('Custom message');
+    // Should retain the original ZodError
+    expect(exception.getZodError()).toBe(parseResult.error);
+  });
+
+  it('should format message when no custom message provided', () => {
+    const parseResult = schema.safeParse(invalidInput);
+    if (parseResult.success) {
+      throw new Error('Expected parseResult to be error');
+    }
+    const exception = new ZodValidationException(parseResult.error);
+    // Default message should include path and error message
+    expect(exception.message).toContain('foo: String must contain at least 3 character');
+  });
+
+  it('getFormattedZodError should return Record<string, string>', () => {
+    const parseResult = schema.safeParse(invalidInput);
+    if (parseResult.success) {
+      throw new Error('Expected parseResult to be error');
+    }
+    const exception = new ZodValidationException(parseResult.error);
+    const formatted = exception.getFormattedZodError();
+    expect(formatted).toHaveProperty('foo');
+    expect(typeof formatted.foo).toBe('string');
+  });
+});

--- a/packages/zod-nestjs/src/lib/exception.spec.ts
+++ b/packages/zod-nestjs/src/lib/exception.spec.ts
@@ -11,7 +11,6 @@ describe('ZodValidationException', () => {
       throw new Error('Expected parseResult to be error');
     }
     const exception = new ZodValidationException(parseResult.error, 'Custom message');
-    // instanceof check
     expect(exception).toBeInstanceOf(ZodValidationException);
     // Prefer custom message for exception.message
     expect(exception.message).toEqual('Custom message');

--- a/packages/zod-nestjs/src/lib/exception.ts
+++ b/packages/zod-nestjs/src/lib/exception.ts
@@ -1,0 +1,39 @@
+import { BadRequestException } from '@nestjs/common';
+import { ZodError } from 'zod';
+
+/**
+ * Custom exception for Zod validation errors.
+ * This exception exposes the original ZodError instance for advanced error handling.
+ */
+export class ZodValidationException extends BadRequestException {
+  public readonly zodError: ZodError;
+
+  constructor(zodError: ZodError, message?: string) {
+    // If no custom message, concatenate all Zod error messages.
+    const formattedMessage =
+      message ||
+      zodError.errors
+        .map((error) => `${error.path.join('.')}: ${error.message}`)
+        .join(', ');
+    super(formattedMessage);
+    this.zodError = zodError;
+  }
+
+  /**
+   * Returns the original ZodError object.
+   */
+  getZodError(): ZodError {
+    return this.zodError;
+  }
+
+  /**
+   * Returns a formatted object of Zod errors: { path: message }
+   */
+  getFormattedZodError(): Record<string, string> {
+    return this.zodError.errors.reduce((acc, error) => {
+      const path = error.path.join('.');
+      acc[path] = error.message;
+      return acc;
+    }, {} as Record<string, string>);
+  }
+}

--- a/packages/zod-nestjs/src/lib/zod-validation-pipe.spec.ts
+++ b/packages/zod-nestjs/src/lib/zod-validation-pipe.spec.ts
@@ -1,0 +1,47 @@
+import { BadRequestException } from '@nestjs/common';
+import { z } from 'zod';
+import { ZodValidationException } from './exception';
+import {
+  ZodValidationPipe,
+  ZodValidationPipeOptions,
+} from './zod-validation-pipe';
+
+class DummyDto {
+  static zodSchema = z.object({ num: z.number().int() });
+}
+
+describe('ZodValidationPipe', () => {
+  const metadata = { metatype: DummyDto, type: 'body' } as any;
+
+  it('should pass valid data through', () => {
+    const pipe = new ZodValidationPipe();
+    const input = { num: 5 };
+    expect(pipe.transform(input, metadata)).toEqual(input);
+  });
+
+  it('should throw ZodValidationException by default on invalid data', () => {
+    const pipe = new ZodValidationPipe();
+    const input = { num: 'a' };
+    expect(() => pipe.transform(input, metadata)).toThrow(
+      ZodValidationException
+    );
+  });
+
+  it('should throw custom exception when useZodValidationException=false', () => {
+    const options: ZodValidationPipeOptions = {
+      useZodValidationException: false,
+      errorHttpStatusCode: 400,
+    };
+    const pipe = new ZodValidationPipe(options);
+    try {
+      pipe.transform({ num: 'a' }, metadata);
+      throw new Error('Expected exception');
+    } catch (err) {
+      expect(err).toBeInstanceOf(BadRequestException);
+      // Should not be ZodValidationException
+      expect(err).not.toBeInstanceOf(ZodValidationException);
+      // message should be in array<string> format
+      expect(Array.isArray((err as any).response?.message)).toBe(true);
+    }
+  });
+});

--- a/packages/zod-nestjs/src/lib/zod-validation-pipe.spec.ts
+++ b/packages/zod-nestjs/src/lib/zod-validation-pipe.spec.ts
@@ -19,8 +19,12 @@ describe('ZodValidationPipe', () => {
     expect(pipe.transform(input, metadata)).toEqual(input);
   });
 
-  it('should throw ZodValidationException by default on invalid data', () => {
-    const pipe = new ZodValidationPipe();
+  it('should throw ZodValidationException when useZodValidationException=true', () => {
+    const options: ZodValidationPipeOptions = {
+      useZodValidationException: true,
+      errorHttpStatusCode: 400,
+    };
+    const pipe = new ZodValidationPipe(options);
     const input = { num: 'a' };
     expect(() => pipe.transform(input, metadata)).toThrow(
       ZodValidationException
@@ -33,8 +37,9 @@ describe('ZodValidationPipe', () => {
       errorHttpStatusCode: 400,
     };
     const pipe = new ZodValidationPipe(options);
+    const input = { num: 'a' };
     try {
-      pipe.transform({ num: 'a' }, metadata);
+      pipe.transform(input, metadata);
       throw new Error('Expected exception');
     } catch (err) {
       expect(err).toBeInstanceOf(BadRequestException);
@@ -43,5 +48,11 @@ describe('ZodValidationPipe', () => {
       // message should be in array<string> format
       expect(Array.isArray((err as any).response?.message)).toBe(true);
     }
+  });
+
+  it('should throw HTTP error by default on invalid data', () => {
+    const pipe = new ZodValidationPipe();
+    const input = { num: 'a' };
+    expect(() => pipe.transform(input, metadata)).toThrow(BadRequestException);
   });
 });

--- a/packages/zod-nestjs/src/lib/zod-validation-pipe.spec.ts
+++ b/packages/zod-nestjs/src/lib/zod-validation-pipe.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException } from '@nestjs/common';
+import { ArgumentMetadata, BadRequestException } from '@nestjs/common';
 import { z } from 'zod';
 import { ZodValidationException } from './exception';
 import {
@@ -11,7 +11,7 @@ class DummyDto {
 }
 
 describe('ZodValidationPipe', () => {
-  const metadata = { metatype: DummyDto, type: 'body' } as any;
+  const metadata = { metatype: DummyDto, type: 'body' } as ArgumentMetadata;
 
   it('should pass valid data through', () => {
     const pipe = new ZodValidationPipe();

--- a/packages/zod-nestjs/src/lib/zod-validation-pipe.ts
+++ b/packages/zod-nestjs/src/lib/zod-validation-pipe.ts
@@ -16,7 +16,7 @@ import { HTTP_ERRORS_BY_CODE } from './http-errors';
 
 export interface ZodValidationPipeOptions {
   errorHttpStatusCode?: keyof typeof HTTP_ERRORS_BY_CODE;
-  useZodValidationException?: boolean; // New option for custom exception
+  useZodValidationException?: boolean;
 }
 
 @Injectable()

--- a/packages/zod-nestjs/src/lib/zod-validation-pipe.ts
+++ b/packages/zod-nestjs/src/lib/zod-validation-pipe.ts
@@ -4,27 +4,30 @@
  */
 
 import {
-  PipeTransform,
-  Injectable,
   ArgumentMetadata,
   HttpStatus,
+  Injectable,
   Optional,
+  PipeTransform,
 } from '@nestjs/common';
-
 import { ZodDtoStatic } from './create-zod-dto';
+import { ZodValidationException } from './exception';
 import { HTTP_ERRORS_BY_CODE } from './http-errors';
 
 export interface ZodValidationPipeOptions {
   errorHttpStatusCode?: keyof typeof HTTP_ERRORS_BY_CODE;
+  useZodValidationException?: boolean; // New option for custom exception
 }
 
 @Injectable()
 export class ZodValidationPipe implements PipeTransform {
   private readonly errorHttpStatusCode: keyof typeof HTTP_ERRORS_BY_CODE;
+  private readonly useZodValidationException: boolean;
 
   constructor(@Optional() options?: ZodValidationPipeOptions) {
     this.errorHttpStatusCode =
       options?.errorHttpStatusCode || HttpStatus.BAD_REQUEST;
+    this.useZodValidationException = options?.useZodValidationException ?? true;
   }
 
   public transform(value: unknown, metadata: ArgumentMetadata): unknown {
@@ -35,10 +38,16 @@ export class ZodValidationPipe implements PipeTransform {
 
       if (!parseResult.success) {
         const { error } = parseResult;
+
+        // Throw custom ZodValidationException if enabled
+        if (this.useZodValidationException) {
+          throw new ZodValidationException(error);
+        }
+
+        // Fallback: throw standard HTTP error for backward compatibility
         const message = error.errors.map(
           (error) => `${error.path.join('.')}: ${error.message}`
         );
-
         throw new HTTP_ERRORS_BY_CODE[this.errorHttpStatusCode](message);
       }
 

--- a/packages/zod-nestjs/src/lib/zod-validation-pipe.ts
+++ b/packages/zod-nestjs/src/lib/zod-validation-pipe.ts
@@ -27,7 +27,7 @@ export class ZodValidationPipe implements PipeTransform {
   constructor(@Optional() options?: ZodValidationPipeOptions) {
     this.errorHttpStatusCode =
       options?.errorHttpStatusCode || HttpStatus.BAD_REQUEST;
-    this.useZodValidationException = options?.useZodValidationException ?? true;
+    this.useZodValidationException = options?.useZodValidationException ?? false;
   }
 
   public transform(value: unknown, metadata: ArgumentMetadata): unknown {


### PR DESCRIPTION
This PR addresses #209 

- Implements a custom exception (`ZodValidationException`) for zod validation failures.
- Adds unit tests for the new exceptions and related functionality.
- Updates the README to document the new feature.