### PR TITLE
fix: @ApiSchema inheritance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19056,7 +19056,7 @@
     },
     "packages/zod-nestjs": {
       "name": "@anatine/zod-nestjs",
-      "version": "2.0.11",
+      "version": "2.0.12",
       "license": "MIT",
       "peerDependencies": {
         "@anatine/zod-openapi": "^2.0.1",

--- a/packages/zod-nestjs/src/lib/patch-nest-swagger.ts
+++ b/packages/zod-nestjs/src/lib/patch-nest-swagger.ts
@@ -5,8 +5,8 @@
  * This file was copied from:
  *   https://github.com/kbkk/abitia/blob/master/packages/zod-dto/src/OpenApi/patchNestjsSwagger.ts
  */
-import {generateSchema} from '@anatine/zod-openapi';
-import type {SchemaObject} from 'openapi3-ts/oas31';
+import { generateSchema } from '@anatine/zod-openapi';
+import type { SchemaObject } from 'openapi3-ts/oas31';
 
 interface Type<T = any> extends Function {
   new (...args: any[]): T;
@@ -43,8 +43,10 @@ export const patchNestjsSwagger = (
       return orgExploreModelSchema.call(this, type, schemas, schemaRefsStack);
     }
 
-    schemas[type.name] = generateSchema(type.zodSchema, false, openApiVersion);
+    const { schemaName } = this.getSchemaMetadata(type);
 
-    return type.name;
+    schemas[schemaName] = generateSchema(type.zodSchema, false, openApiVersion);
+
+    return schemaName;
   };
 };


### PR DESCRIPTION
There existed a bug in the `@nestjs/swagger` package where the `@ApiSchema` decorator would not work as expected when applied to child classes (see issue [3160](https://github.com/nestjs/swagger/issues/3160) for full details).

This issue has been fixed (see PR [3164](https://github.com/nestjs/swagger/pull/3164)), however the [patchNestjsSwagger](https://github.com/anatine/zod-plugins/blob/main/packages/zod-nestjs/src/lib/patch-nest-swagger.ts) function from this repo's `zod-nestjs` package overrides the fix with the old method of obtaining the schema name.

This PR updates the patch function to obtain the schema name in the same way as the original function that is being patched.