### PR TITLE
[zod-mock]: add recursion depth control feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19056,7 +19056,7 @@
     },
     "packages/zod-nestjs": {
       "name": "@anatine/zod-nestjs",
-      "version": "2.0.11",
+      "version": "2.0.12",
       "license": "MIT",
       "peerDependencies": {
         "@anatine/zod-openapi": "^2.0.1",

--- a/packages/zod-mock/README.md
+++ b/packages/zod-mock/README.md
@@ -2,7 +2,7 @@
 
 Generates a mock data object using [faker.js](https://www.npmjs.com/package/@faker-js/faker) from a [Zod](https://github.com/colinhacks/zod) schema.
 
-----
+---
 
 ## Installation
 
@@ -12,7 +12,7 @@ Generates a mock data object using [faker.js](https://www.npmjs.com/package/@fak
 npm install zod @faker-js/faker @anatine/zod-mock
 ```
 
-----
+---
 
 ## Usage
 
@@ -21,18 +21,18 @@ npm install zod @faker-js/faker @anatine/zod-mock
 ```typescript
 import { generateMock } from '@anatine/zod-mock';
 const schema = z.object({
-      uid: z.string().nonempty(),
-      theme: z.enum([`light`, `dark`]),
-      email: z.string().email().optional(),
-      phoneNumber: z.string().min(10).optional(),
-      avatar: z.string().url().optional(),
-      jobTitle: z.string().optional(),
-      otherUserEmails: z.array(z.string().email()),
-      stringArrays: z.array(z.string()),
-      stringLength: z.string().transform((val) => val.length),
-      numberCount: z.number().transform((item) => `total value = ${item}`),
-      age: z.number().min(18).max(120),
-    });
+  uid: z.string().nonempty(),
+  theme: z.enum([`light`, `dark`]),
+  email: z.string().email().optional(),
+  phoneNumber: z.string().min(10).optional(),
+  avatar: z.string().url().optional(),
+  jobTitle: z.string().optional(),
+  otherUserEmails: z.array(z.string().email()),
+  stringArrays: z.array(z.string()),
+  stringLength: z.string().transform((val) => val.length),
+  numberCount: z.number().transform((item) => `total value = ${item}`),
+  age: z.number().min(18).max(120),
+});
 const mockData = generateMock(schema);
 // ...
 ```
@@ -47,27 +47,15 @@ This will generate mock data similar to:
   "phoneNumber": "1-665-405-2226",
   "avatar": "https://cdn.fakercloud.com/avatars/olaolusoga_128.jpg",
   "jobTitle": "Lead Brand Facilitator",
-  "otherUserEmails": [
-    "Wyman58@example.net",
-    "Ignacio_Nader@example.org",
-    "Jorge_Bradtke@example.org",
-    "Elena.Torphy33@example.org",
-    "Kelli_Bartoletti@example.com"
-  ],
-  "stringArrays": [
-    "quisquam",
-    "corrupti",
-    "atque",
-    "sunt",
-    "voluptatem"
-  ],
+  "otherUserEmails": ["Wyman58@example.net", "Ignacio_Nader@example.org", "Jorge_Bradtke@example.org", "Elena.Torphy33@example.org", "Kelli_Bartoletti@example.com"],
+  "stringArrays": ["quisquam", "corrupti", "atque", "sunt", "voluptatem"],
   "stringLength": 4,
   "numberCount": "total value = 25430",
   "age": 110
 }
 ```
 
-----
+---
 
 ## Overriding string mocks
 
@@ -90,7 +78,7 @@ const mockData = generateMock(schema, {
 });
 ```
 
-----
+---
 
 ## Adding a seed generator
 
@@ -107,7 +95,7 @@ const second = generateMock(schema, { seed });
 expect(first).toEqual(second);
 ```
 
-----
+---
 
 ## Adding a custom mock mapper
 
@@ -116,11 +104,7 @@ Once drilled down to deliver a string, number, boolean, or other primitive value
 You can add your own key/fn mapper in the options.
 
 ```typescript
-
-export function mockeryMapper(
-  keyName: string,
-  fakerInstance: Faker
-): FakerFunction | undefined {
+export function mockeryMapper(keyName: string, fakerInstance: Faker): FakerFunction | undefined {
   const keyToFnMap: Record<string, FakerFunction> = {
     image: fakerInstance.image.url,
     imageurl: fakerInstance.image.url,
@@ -130,11 +114,9 @@ export function mockeryMapper(
     uuid: fakerInstance.string.uuid,
     boolean: fakerInstance.datatype.boolean,
     // Email more guaranteed to be random for testing
-    email: () => fakerInstance.database.mongodbObjectId() + '@example.com'
+    email: () => fakerInstance.database.mongodbObjectId() + '@example.com',
   };
-  return keyName && keyName.toLowerCase() in keyToFnMap
-    ? keyToFnMap[keyName.toLowerCase() as never]
-    : undefined;
+  return keyName && keyName.toLowerCase() in keyToFnMap ? keyToFnMap[keyName.toLowerCase() as never] : undefined;
 }
 
 const schema = z.object({
@@ -144,10 +126,28 @@ const schema = z.object({
 });
 
 const result = generateMock(schema, { mockeryMapper });
-
 ```
 
-----
+---
+
+## Controlling recursion depth for self-referential schemas
+
+When a schema references itself (directly or via `z.lazy`), mocking can recurse indefinitely. Use the `levelLimit` option to cap how many times the same schema instance can expand along a single path. The default is `1`.
+
+```typescript
+// a simple linked-list like schema
+const Node: z.ZodType<any> = z.lazy(() => z.object({ value: z.string(), next: Node.optional() }));
+
+// default: stops at one expansion, Node.next will be undefined
+const mock1 = generateMock(Node);
+
+// allow one nested next node (two levels total)
+const mock2 = generateMock(Node, { levelLimit: 2 });
+```
+
+This limit applies per schema instance along a single generation path and prevents infinite loops while still allowing controlled depth.
+
+---
 
 ## Behind the Scenes
 
@@ -167,18 +167,18 @@ const result = generateMock(schema, { mockeryMapper });
 
   If **`zod-mock`** does not yet support a Zod type used in your schema, you may provide a backup mock function to use for that particular type.
 
-  ``` typescript
+  ```typescript
   const schema = z.object({
-    anyVal: z.any()
+    anyVal: z.any(),
   });
   const mockData = generateMock(schema, {
     backupMocks: {
-      ZodAny: () => 'a value'
-    }
+      ZodAny: () => 'a value',
+    },
   });
   ```
 
-----
+---
 
 ## Missing Features
 
@@ -195,7 +195,7 @@ const result = generateMock(schema, { mockeryMapper });
   - ZodUnion
   - ZodUnknown
 
-----
+---
 
 ## Credits
 
@@ -203,6 +203,6 @@ const result = generateMock(schema, { mockeryMapper });
 
   A great lib that provided some insights on dealing with various zod types.
 
-----
+---
 
 This library is part of a nx monorepo [@anatine/zod-plugins](https://github.com/anatine/zod-plugins).

--- a/packages/zod-mock/src/lib/zod-mock.spec.ts
+++ b/packages/zod-mock/src/lib/zod-mock.spec.ts
@@ -1,6 +1,6 @@
+import { faker, Faker } from '@faker-js/faker';
 import { z } from 'zod';
 import { generateMock, ZodMockError } from './zod-mock';
-import { faker, Faker } from '@faker-js/faker';
 import { FakerFunction } from './zod-mockery-map';
 
 describe('zod-mock', () => {
@@ -118,7 +118,7 @@ describe('zod-mock', () => {
 
   it('Should manually mock string key names to set values when the validation has regex', () => {
     const schema = z.object({
-      telephone: z.string().regex(/^\+[1-9]\d{1,14}$/)
+      telephone: z.string().regex(/^\+[1-9]\d{1,14}$/),
     });
 
     const stringMap = {
@@ -638,6 +638,30 @@ describe('zod-mock', () => {
   });
   it('ZodLazy', () => {
     expect(generateMock(z.lazy(() => z.string()))).toBeTruthy();
+  });
+
+  describe('recursion levelLimit', () => {
+    it('defaults to 1 and prevents infinite recursion', () => {
+      const Node: z.ZodType<any> = z.lazy(() =>
+        z.object({ value: z.string(), next: Node.optional() })
+      );
+
+      const mock = generateMock(Node);
+      expect(mock.value).toBeTruthy();
+      expect(mock.next).toBeUndefined();
+    });
+
+    it('allows deeper expansion when levelLimit is increased', () => {
+      const Node: z.ZodType<any> = z.lazy(() =>
+        z.object({ value: z.string(), next: Node.optional() })
+      );
+
+      const mock = generateMock(Node, { levelLimit: 2 });
+      expect(mock.value).toBeTruthy();
+      expect(mock.next).toBeDefined();
+      expect(mock.next.value).toBeTruthy();
+      expect(mock.next.next).toBeUndefined();
+    });
   });
 
   it('Options seed value will return the same random numbers', () => {

--- a/packages/zod-mock/src/lib/zod-mock.ts
+++ b/packages/zod-mock/src/lib/zod-mock.ts
@@ -3,12 +3,12 @@ import { faker } from '@faker-js/faker';
 import * as randExp from 'randexp';
 import {
   AnyZodObject,
-  z,
-  ZodTypeAny,
-  ZodType,
-  ZodString,
   ZodRecord,
+  ZodString,
+  ZodType,
+  ZodTypeAny,
   util,
+  z,
 } from 'zod';
 import {
   MockeryMapper,
@@ -211,7 +211,8 @@ function parseString(
     targetStringLength > 10
       ? fakerInstance.lorem.word()
       : fakerInstance.lorem.word({ length: targetStringLength });
-  const dateGenerator = () => fakerInstance.date.recent().toISOString().substring(0,10);
+  const dateGenerator = () =>
+    fakerInstance.date.recent().toISOString().substring(0, 10);
   const datetimeGenerator = () => fakerInstance.date.recent().toISOString();
   const stringGenerators = {
     default: defaultGenerator,
@@ -627,6 +628,17 @@ export interface GenerateMockOptions {
    * Faker class instance for mocking
    */
   faker?: FakerClass;
+
+  /**
+   * Limit how many times the same schema instance can be expanded within a single generation path.
+   * Helps prevent infinite recursion for self-referential schemas. Default: 1
+   */
+  levelLimit?: number;
+
+  /**
+   * INTERNAL: Tracks expansion counts per schema instance during a single generateMock call.
+   */
+  __levelsMap__?: WeakMap<ZodTypeAny, number>;
 }
 
 export function generateMock<T extends ZodTypeAny>(
@@ -634,6 +646,16 @@ export function generateMock<T extends ZodTypeAny>(
   options?: GenerateMockOptions
 ): z.infer<typeof zodRef> {
   try {
+    // initialize recursion tracking
+    const levelLimit = options?.levelLimit ?? 1;
+    if (!options) options = {};
+    if (!options.__levelsMap__) options.__levelsMap__ = new WeakMap();
+    const currentLevel = options.__levelsMap__.get(zodRef) ?? 0;
+    if (currentLevel >= levelLimit) {
+      return undefined as unknown as z.infer<typeof zodRef>;
+    }
+    options.__levelsMap__.set(zodRef, currentLevel + 1);
+
     const fakerInstance = options?.faker || faker;
     if (options?.seed) {
       fakerInstance.seed(
@@ -642,24 +664,36 @@ export function generateMock<T extends ZodTypeAny>(
     }
     const typeName = zodRef._def.typeName as WorkerKeys;
     if (typeName in workerMap) {
-      return workerMap[typeName](zodRef as never, options);
+      const result = workerMap[typeName](zodRef as never, options);
+      return result as z.infer<typeof zodRef>;
     } else if (options?.backupMocks && typeName in options.backupMocks) {
       // check for a generator match in the options.
       // workaround for unimplemented Zod types
       const generator = options.backupMocks[typeName];
       if (generator) {
-        return generator(zodRef as never, options);
+        const result = generator(zodRef as never, options);
+        return result as z.infer<typeof zodRef>;
       }
     } else if (options?.throwOnUnknownType) {
       throw new ZodMockError(typeName);
     }
-    return undefined;
+    return undefined as unknown as z.infer<typeof zodRef>;
   } catch (err) {
     if (err instanceof ZodMockError) {
       throw err;
     }
     console.error(err);
-    return undefined;
+    return undefined as unknown as z.infer<typeof zodRef>;
+  } finally {
+    // decrement recursion tracking for this node
+    if (options?.__levelsMap__) {
+      const curr = options.__levelsMap__.get(zodRef) ?? 0;
+      if (curr <= 1) {
+        options.__levelsMap__.delete(zodRef);
+      } else {
+        options.__levelsMap__.set(zodRef, curr - 1);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### Pull Request: Prevent infinite recursion in zod-mock with levelLimit option

- **Scope**: `packages/zod-mock`
- **Type**: Feature/Fix

### Summary
Adds a recursion guard to `generateMock` to prevent infinite loops for self-referential schemas. Introduces a new option `levelLimit` (default: 1) to control how many times the same schema instance can expand along a single generation path.

### Motivation
Self-referential schemas (e.g., via `z.lazy`) could cause infinite recursion during mock generation. This change provides a safe default and a configurable limit to support controlled depth.

### Changes
- Add `levelLimit?: number` to `GenerateMockOptions` (default = 1).
- Add internal `__levelsMap__?: WeakMap<ZodTypeAny, number>` to track per-call expansion counts.
- Return `undefined` when the limit is exceeded at a specific node to stop further expansion.
- Tests:
  - Default behavior prevents recursion (stops at one level).
  - Custom depth when `levelLimit` is increased.
- Docs:
  - Add “Controlling recursion depth for self-referential schemas” section to `README.md` with examples.

### Usage
```ts
const Node: z.ZodType<any> = z.lazy(() =>
  z.object({ value: z.string(), next: Node.optional() })
);

// default: stops at one expansion (next is undefined)
const mock1 = generateMock(Node);

// allow one nested node (two levels total)
const mock2 = generateMock(Node, { levelLimit: 2 });
```

### Backwards Compatibility
- No breaking changes. Default behavior is safe for self-referential schemas and does not affect non-recursive schemas.

### Tests
- Added unit tests to validate default and custom recursion depth behaviors.

### Documentation
- Updated `packages/zod-mock/README.md` with a new section describing `levelLimit`, rationale, and examples.

If there’s a preferred default depth or alternative handling strategy (e.g., truncating with a sentinel value), I can adjust accordingly.