### PR TITLE
allow zod v3 or v4 peer dependency

### DIFF
--- a/packages/zod-mock/package.json
+++ b/packages/zod-mock/package.json
@@ -22,7 +22,7 @@
   ],
   "peerDependencies": {
     "@faker-js/faker": "^7.0.0 || ^8.0.0 || ^9.0.0",
-    "zod": "^3.21.4"
+    "zod": "^3.0.0 || ^4.0.0"
   },
   "dependencies": {
     "randexp": "^0.5.3"


### PR DESCRIPTION
Tested and working great with Zod 4, so this relaxes compatibility for the peer dep.