### PR TITLE
[zod-mock]: add requiredOnly option to generate only required fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19056,7 +19056,7 @@
     },
     "packages/zod-nestjs": {
       "name": "@anatine/zod-nestjs",
-      "version": "2.0.11",
+      "version": "2.0.12",
       "license": "MIT",
       "peerDependencies": {
         "@anatine/zod-openapi": "^2.0.1",

--- a/packages/zod-mock/README.md
+++ b/packages/zod-mock/README.md
@@ -109,6 +109,29 @@ expect(first).toEqual(second);
 
 ----
 
+## Generating only required fields
+
+You can generate mock data with only required fields by setting the `requiredOnly` option to `true`. This will skip generating values for optional and nullable fields.
+
+```typescript
+const schema = z.object({
+  requiredField: z.string(),
+  optionalField: z.string().optional(),
+  nullableField: z.string().nullable(),
+});
+const mockData = generateMock(schema, { requiredOnly: true });
+// mockData will be:
+// {
+//   requiredField: "some string",
+//   optionalField: undefined,
+//   nullableField: undefined
+// }
+```
+
+This is useful when you want to test with minimal data or ensure your code handles missing optional fields correctly.
+
+----
+
 ## Adding a custom mock mapper
 
 Once drilled down to deliver a string, number, boolean, or other primitive value a function with a matching name is searched for in faker.

--- a/packages/zod-mock/src/lib/zod-mock.spec.ts
+++ b/packages/zod-mock/src/lib/zod-mock.spec.ts
@@ -806,4 +806,90 @@ describe('zod-mock', () => {
       }
     );
   });
+
+  describe('requiredOnly option', () => {
+    it('should only generate required fields when requiredOnly is true', () => {
+      const schema = z.object({
+        requiredString: z.string(),
+        requiredNumber: z.number(),
+        optionalString: z.string().optional(),
+        optionalNumber: z.number().optional(),
+        nullableString: z.string().nullable(),
+        nullableNumber: z.number().nullable(),
+      });
+
+      const mockData = generateMock(schema, { requiredOnly: true });
+
+      // Required fields should be generated
+      expect(typeof mockData.requiredString).toEqual('string');
+      expect(typeof mockData.requiredNumber).toEqual('number');
+
+      // Optional and nullable fields should be undefined
+      expect(mockData.optionalString).toBeUndefined();
+      expect(mockData.optionalNumber).toBeUndefined();
+      expect(mockData.nullableString).toBeUndefined();
+      expect(mockData.nullableNumber).toBeUndefined();
+    });
+
+    it('should generate all fields when requiredOnly is false or not set', () => {
+      const schema = z.object({
+        requiredString: z.string(),
+        optionalString: z.string().optional(),
+        nullableString: z.string().nullable(),
+      });
+
+      const mockData = generateMock(schema, { requiredOnly: false });
+
+      // All fields should be generated
+      expect(typeof mockData.requiredString).toEqual('string');
+      expect(typeof mockData.optionalString).toEqual('string');
+      expect(typeof mockData.nullableString).toEqual('string');
+    });
+
+    it('should work with nested objects when requiredOnly is true', () => {
+      const schema = z.object({
+        required: z.string(),
+        optional: z.string().optional(),
+        nested: z.object({
+          requiredNested: z.number(),
+          optionalNested: z.number().optional(),
+        }),
+      });
+
+      const mockData = generateMock(schema, { requiredOnly: true });
+
+      expect(typeof mockData.required).toEqual('string');
+      expect(mockData.optional).toBeUndefined();
+      expect(typeof mockData.nested.requiredNested).toEqual('number');
+      expect(mockData.nested.optionalNested).toBeUndefined();
+    });
+
+    it('should work with arrays when requiredOnly is true', () => {
+      const schema = z.object({
+        requiredArray: z.array(z.string()),
+        optionalArray: z.array(z.string()).optional(),
+      });
+
+      const mockData = generateMock(schema, { requiredOnly: true });
+
+      expect(Array.isArray(mockData.requiredArray)).toBeTruthy();
+      expect(mockData.requiredArray.length).toBeGreaterThan(0);
+      expect(mockData.optionalArray).toBeUndefined();
+    });
+
+    it('should handle default values with requiredOnly option', () => {
+      const schema = z.object({
+        requiredField: z.string(),
+        optionalField: z.string().optional(),
+        defaultField: z.string().default('default value'),
+      });
+
+      const mockData = generateMock(schema, { requiredOnly: true });
+
+      expect(typeof mockData.requiredField).toEqual('string');
+      expect(mockData.optionalField).toBeUndefined();
+      // Default fields are still generated even with requiredOnly
+      expect(typeof mockData.defaultField).toEqual('string');
+    });
+  });
 });

--- a/packages/zod-mock/src/lib/zod-mock.ts
+++ b/packages/zod-mock/src/lib/zod-mock.ts
@@ -357,6 +357,9 @@ function parseOptional(
   zodRef: z.ZodOptional<ZodTypeAny> | z.ZodNullable<ZodTypeAny>,
   options?: GenerateMockOptions
 ) {
+  if (options?.requiredOnly) {
+    return undefined;
+  }
   return generateMock<ZodTypeAny>(zodRef.unwrap(), options);
 }
 
@@ -627,6 +630,11 @@ export interface GenerateMockOptions {
    * Faker class instance for mocking
    */
   faker?: FakerClass;
+
+  /**
+   * Set to true to only generate required fields (skip optional and nullable fields)
+   */
+  requiredOnly?: boolean;
 }
 
 export function generateMock<T extends ZodTypeAny>(


### PR DESCRIPTION
## Problem
Users needed a way to generate mock data with only required fields populated, to test how their applications handle scenarios where optional and nullable fields are absent.

## Solution
Added a `requiredOnly` boolean option to the mock generator that skips generating values for optional and nullable fields, while maintaining full backward compatibility.