### PR TITLE
fix(zod-nestjs): tolerate @nestjs/swagger 11.4.3 exports map

### DIFF
--- a/packages/zod-nestjs/src/lib/patch-nest-swagger.spec.ts
+++ b/packages/zod-nestjs/src/lib/patch-nest-swagger.spec.ts
@@ -1,0 +1,32 @@
+import * as path from 'path';
+import { patchNestjsSwagger } from './patch-nest-swagger';
+
+// Same absolute-path bypass as the patch (@nestjs/swagger 11.4.3+ exports map).
+const loadSchemaObjectFactoryModule = () => {
+  const pkgPath = require.resolve('@nestjs/swagger/package.json');
+  const factoryPath = path.join(
+    path.dirname(pkgPath),
+    'dist',
+    'services',
+    'schema-object-factory'
+  );
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  return require(factoryPath) as typeof import('@nestjs/swagger/dist/services/schema-object-factory');
+};
+
+describe('patchNestjsSwagger', () => {
+  it('loads SchemaObjectFactory and installs the patch with no arguments', () => {
+    // Regression: @nestjs/swagger 11.4.3 "exports" map broke the deep require.
+    expect(() => patchNestjsSwagger()).not.toThrow();
+
+    const { SchemaObjectFactory } = loadSchemaObjectFactoryModule();
+    expect(typeof SchemaObjectFactory.prototype.exploreModelSchema).toBe(
+      'function'
+    );
+  });
+
+  it('honours an explicitly-injected schemaObjectFactoryModule', () => {
+    const injected = loadSchemaObjectFactoryModule();
+    expect(() => patchNestjsSwagger(injected)).not.toThrow();
+  });
+});

--- a/packages/zod-nestjs/src/lib/patch-nest-swagger.ts
+++ b/packages/zod-nestjs/src/lib/patch-nest-swagger.ts
@@ -5,6 +5,7 @@
  * This file was copied from:
  *   https://github.com/kbkk/abitia/blob/master/packages/zod-dto/src/OpenApi/patchNestjsSwagger.ts
  */
+import * as path from 'path';
 import { generateSchema } from '@anatine/zod-openapi';
 import type { SchemaObject } from 'openapi3-ts/oas31';
 
@@ -19,8 +20,15 @@ export const patchNestjsSwagger = (
   schemaObjectFactoryModule: SchemaObjectFactoryModule | undefined = undefined,
   openApiVersion: '3.0' | '3.1' = '3.0'
 ): void => {
+  // @nestjs/swagger 11.4.3+ "exports" map hides this subpath; resolve absolutely.
+  const swaggerRoot = path.dirname(
+    require.resolve('@nestjs/swagger/package.json')
+  );
   const { SchemaObjectFactory } = (schemaObjectFactoryModule ??
-    require('@nestjs/swagger/dist/services/schema-object-factory')) as SchemaObjectFactoryModule;
+    require(path.join(
+      swaggerRoot,
+      'dist/services/schema-object-factory'
+    ))) as SchemaObjectFactoryModule;
 
   const orgExploreModelSchema =
     SchemaObjectFactory.prototype.exploreModelSchema;


### PR DESCRIPTION
  ## Summary

  `@nestjs/swagger@11.4.3` added a `package.json#exports` map that no longer exposes `dist/services/schema-object-factory`. The deep `require` inside `patchNestjsSwagger` now throws
  `ERR_PACKAGE_PATH_NOT_EXPORTED` in plain Node, and webpack-bundled consumers (e.g. `serverless-webpack` Lambdas) crash at startup with `Cannot find module '@nestjs/swagger/dist/services/schema-object-factory'`.

  11.4.0 - 11.4.2 do not have an `exports` field and work fine. The current `peerDependencies` range (`^11.0.0`) still allows 11.4.3, so a fresh `npm install` today pulls the broken combination.

  Fixes #267 

  ## Fix

  Resolve the factory file via the still-exported `@nestjs/swagger/package.json`, then load it by absolute path. Node's exports gating only applies to package-specifier resolution, not to absolute paths, so the
  factory loads correctly without depending on any private surface of `@nestjs/swagger`.

  The function signature is unchanged; existing callers that pass an explicit `schemaObjectFactoryModule` keep working as before.

  ## Verification

  Three-step proof in the same spec file, against the same Jest config:

  | Code | `@nestjs/swagger` | Result |
  |---|---|---|
  | `main` (unpatched) | `11.4.3` | FAIL — `patchNestjsSwagger()` throws |
  | this PR | `11.4.3` | PASS |
  | this PR | `11.4.2` | PASS (backward compat) |

  ## Tests

  Added `patch-nest-swagger.spec.ts` covering:
  1. `patchNestjsSwagger()` with no arguments must not throw (regression guard).
  2. Explicit `schemaObjectFactoryModule` injection still works.

*Drafted with the assistance of Claude (Anthropic). Reproduction, fix, and tests verified locally on Node 22 against `@nestjs/swagger` 11.4.2 and 11.4.3.*