### PR TITLE
fix(zod-openapi): bump vulnerable dependency `ts-deepmerge`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19071,11 +19071,20 @@
       "version": "2.2.8",
       "license": "MIT",
       "dependencies": {
-        "ts-deepmerge": "^6.0.3"
+        "ts-deepmerge": "^8.0.0"
       },
       "peerDependencies": {
         "openapi3-ts": "^4.1.2",
         "zod": "^3.20.0"
+      }
+    },
+    "packages/zod-openapi/node_modules/ts-deepmerge": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-8.0.0.tgz",
+      "integrity": "sha512-133O+10nJmVI8w5xeVZPEv5PIrv7iaUae07wv1aH8XJH95Ur6YIhWAPhPyP1YPlbPS9fCVcNIZTu7m8urRVF0A==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14.13.1"
       }
     }
   },
@@ -19265,7 +19274,14 @@
     "@anatine/zod-openapi": {
       "version": "file:packages/zod-openapi",
       "requires": {
-        "ts-deepmerge": "^6.0.3"
+        "ts-deepmerge": "^8.0.0"
+      },
+      "dependencies": {
+        "ts-deepmerge": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-8.0.0.tgz",
+          "integrity": "sha512-133O+10nJmVI8w5xeVZPEv5PIrv7iaUae07wv1aH8XJH95Ur6YIhWAPhPyP1YPlbPS9fCVcNIZTu7m8urRVF0A=="
+        }
       }
     },
     "@angular-devkit/core": {

--- a/packages/zod-openapi/package.json
+++ b/packages/zod-openapi/package.json
@@ -21,7 +21,7 @@
     "swagger"
   ],
   "dependencies": {
-    "ts-deepmerge": "^6.0.3"
+    "ts-deepmerge": "^8.0.0"
   },
   "peerDependencies": {
     "zod": "^3.20.0",

--- a/packages/zod-openapi/src/lib/zod-openapi.ts
+++ b/packages/zod-openapi/src/lib/zod-openapi.ts
@@ -1,5 +1,5 @@
 import type { SchemaObject, SchemaObjectType } from 'openapi3-ts/oas31';
-import merge from 'ts-deepmerge';
+import { merge } from 'ts-deepmerge';
 import { AnyZodObject, z, ZodTypeAny } from 'zod';
 
 export type AnatineSchemaObject = SchemaObject & { hideDefinitions?: string[] };


### PR DESCRIPTION
This PR bumps vulnerable dependency `ts-deepmerge` in `@anatine/zod-openapi` (https://github.com/advisories/GHSA-87mf-gv2c-c62c).